### PR TITLE
[feature] users can see/send messages in a room

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 Harmony is an open-source, real-time chat application --- in the vein of classic
 IRC, Slack, & Discord---powered by Phoenix LiveView.
 
-![build](https://github.com/etothepiipower/harmony/actions/workflows/build.yml/badge.svg?branch=develop)
+[![build](https://github.com/etothepiipower/harmony/actions/workflows/build.yml/badge.svg?branch=develop)](https://github.com/etothepiipower/harmony/actions/workflows/build.yml)
 
 To start your Phoenix server:
 
   * Run `mix setup` to install and setup dependencies
-  * Create and migrate your database with 'mix ecto.setup'
+  * Create and migrate your database with `mix ecto.setup`
+  * Download npm assets with `cd assets && npm install && cd ..`
   * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
-
 
 ## Contributing
 
@@ -23,7 +23,8 @@ We use `ExUnit`` to test the application and (planned) GitHub Actions to run the
  *  Write tests and implementation code
  *  Run the test suite with `mix test`
  *  Push your changes to your fork
- *  Once the tests pass in CI, you can submit a pull request.
+ *  Once the tests pass locally, you can submit a pull request. The CI workflow
+    will run the tests again and a maintainer will consider your changes.
 
 Because we are using [ PhoenixTest ](https://hexdocs.pm/phoenix_test/PhoenixTest.html)
 for feature tests, we don't need Chromedriver. Yay!
@@ -33,7 +34,7 @@ for feature tests, we don't need Chromedriver. Yay!
 Harmony is in an early stage right now. Planned features include:
 
     * [x]    Rooms
-    * [ ]    Messages
+    * [x]    Messages
     * [ ]    Room groups and ordering
     * [ ]    User profiles
     * [ ]    User roles (admin, moderator, user)

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -23,10 +23,12 @@ import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
 import MessagesList from "./hooks/MessagesList"
 import CtrlEnterSubmit from "./hooks/CtrlEnterSubmit"
+import Timestamp from "./hooks/Timestamp"
 
 const hooks = {
   CtrlEnterSubmit,
   MessagesList,
+  Timestamp,
 }
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -21,9 +21,17 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
+import MessagesList from "./hooks/MessagesList"
+import CtrlEnterSubmit from "./hooks/CtrlEnterSubmit"
+
+const hooks = {
+  CtrlEnterSubmit,
+  MessagesList,
+}
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, {
+  hooks: hooks,
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken}
 })

--- a/assets/js/hooks/CtrlEnterSubmit.js
+++ b/assets/js/hooks/CtrlEnterSubmit.js
@@ -1,0 +1,12 @@
+const CtrlEnterSubmit = {
+  mounted() {
+    this.el.addEventListener('keydown', e => {
+      if (e.ctrlKey && e.key === 'Enter') {
+        this.el.dispatchEvent(new Event("change", {bubbles: true, cancelable: true}));
+        this.el.form.dispatchEvent(new Event("submit", {bubbles: true, cancelable: true}));
+      }
+    });
+  }
+};
+
+export default CtrlEnterSubmit;

--- a/assets/js/hooks/MessagesList.js
+++ b/assets/js/hooks/MessagesList.js
@@ -1,0 +1,10 @@
+const MessagesList = {
+  mounted() {
+    this.el.scrollTop = this.el.scrollHeight;
+  },
+  updated() {
+    this.el.scrollTop = this.el.scrollHeight;
+  }
+};
+
+export default MessagesList;

--- a/assets/js/hooks/Timestamp.js
+++ b/assets/js/hooks/Timestamp.js
@@ -1,0 +1,66 @@
+const Timestamp = {
+  mounted() {
+    this.updateTime = () => {
+      const now = new Date();
+      const timestamp = new Date(this.el.dataset.timestamp);
+      this.el.textContent = timeAgo(now, timestamp);
+    };
+    this.intervalId = setInterval(this.updateTime, 1000);
+    this.updateTime() // force update the inital absolute timestamps
+  },
+  destroyed() {
+    clearInterval(this.intervalId);
+  }
+}
+
+timeAgo = (now, then) => {
+  var seconds = Math.floor((now - then) / 1000);
+
+  var interval = seconds;
+  if (interval < 10) {
+    return "now";
+  }
+  if (interval < 60) {
+    return "less than a minute ago";
+  }
+
+  interval = seconds / 60;
+  if (interval < 2) {
+    return "a minute ago";
+  }
+  if (interval < 75) {
+    return Math.floor(interval) + " minutes ago";
+  }
+
+  interval = seconds / 3600;
+  if (interval < 2) {
+    return "an hour ago";
+  }
+  if (interval < 30) {
+    return Math.floor(interval) + " hours ago";
+  }
+
+  interval = seconds / 86400;
+  if (interval < 2) {
+    return "a day ago";
+  }
+  if (interval < 38) {
+    return Math.floor(interval) + " days ago";
+  }
+
+  interval = seconds / 2592000;
+  if (interval < 2) {
+    return "a month ago";
+  }
+  if (interval < 13) {
+    return Math.floor(interval) + " months ago";
+  }
+
+  interval = seconds / 31536000;
+  if (interval < 2) {
+    return "a year ago";
+  }
+  return Math.floor(interval) + " years ago";
+}
+
+export default Timestamp;

--- a/assets/js/hooks/Timestamp.js
+++ b/assets/js/hooks/Timestamp.js
@@ -1,9 +1,13 @@
+import TimeAgo from 'javascript-time-ago'
+import en from 'javascript-time-ago/locale/en'
+TimeAgo.addDefaultLocale(en)
+const timeAgo = new TimeAgo('en-US')
+
 const Timestamp = {
   mounted() {
     this.updateTime = () => {
-      const now = new Date();
       const timestamp = new Date(this.el.dataset.timestamp);
-      this.el.textContent = timeAgo(now, timestamp);
+      this.el.textContent = timeAgo.format(timestamp);
     };
     this.intervalId = setInterval(this.updateTime, 1000);
     this.updateTime() // force update the inital absolute timestamps
@@ -11,56 +15,6 @@ const Timestamp = {
   destroyed() {
     clearInterval(this.intervalId);
   }
-}
-
-timeAgo = (now, then) => {
-  var seconds = Math.floor((now - then) / 1000);
-
-  var interval = seconds;
-  if (interval < 10) {
-    return "now";
-  }
-  if (interval < 60) {
-    return "less than a minute ago";
-  }
-
-  interval = seconds / 60;
-  if (interval < 2) {
-    return "a minute ago";
-  }
-  if (interval < 75) {
-    return Math.floor(interval) + " minutes ago";
-  }
-
-  interval = seconds / 3600;
-  if (interval < 2) {
-    return "an hour ago";
-  }
-  if (interval < 30) {
-    return Math.floor(interval) + " hours ago";
-  }
-
-  interval = seconds / 86400;
-  if (interval < 2) {
-    return "a day ago";
-  }
-  if (interval < 38) {
-    return Math.floor(interval) + " days ago";
-  }
-
-  interval = seconds / 2592000;
-  if (interval < 2) {
-    return "a month ago";
-  }
-  if (interval < 13) {
-    return Math.floor(interval) + " months ago";
-  }
-
-  interval = seconds / 31536000;
-  if (interval < 2) {
-    return "a year ago";
-  }
-  return Math.floor(interval) + " years ago";
 }
 
 export default Timestamp;

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "assets",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "javascript-time-ago": "^2.5.11"
+      }
+    },
+    "node_modules/javascript-time-ago": {
+      "version": "2.5.11",
+      "resolved": "https://registry.npmjs.org/javascript-time-ago/-/javascript-time-ago-2.5.11.tgz",
+      "integrity": "sha512-Zeyf5R7oM1fSMW9zsU3YgAYwE0bimEeF54Udn2ixGd8PUwu+z1Yc5t4Y8YScJDMHD6uCx6giLt3VJR5K4CMwbg==",
+      "license": "MIT",
+      "dependencies": {
+        "relative-time-format": "^1.1.6"
+      }
+    },
+    "node_modules/relative-time-format": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/relative-time-format/-/relative-time-format-1.1.6.tgz",
+      "integrity": "sha512-aCv3juQw4hT1/P/OrVltKWLlp15eW1GRcwP1XdxHrPdZE9MtgqFpegjnTjLhi2m2WI9MT/hQQtE+tjEWG1hgkQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "javascript-time-ago": "^2.5.11"
+  }
+}

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -1,6 +1,8 @@
 defmodule Harmony.Chat do
-  alias Harmony.{Chat.Room, Repo}
+  alias Harmony.{Chat.Room, Chat.Message, Repo}
   import Ecto.Query
+
+  # Chat.Room
 
   def list_rooms do
     from(Room)
@@ -26,5 +28,15 @@ defmodule Harmony.Chat do
     room
     |> Room.changeset(attrs)
     |> Repo.update()
+  end
+
+  # Chat.Message
+
+  def list_messages(%Room{id: room_id}) do
+    Message
+    |> where([m], m.room_id == ^room_id)
+    |> order_by([m], asc: :inserted_at, asc: :id)
+    |> preload(:user)
+    |> Repo.all()
   end
 end

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -1,5 +1,6 @@
 defmodule Harmony.Chat do
   alias Harmony.{Chat.Room, Chat.Message, Repo}
+  alias Harmony.Accounts.User
   import Ecto.Query
 
   # Chat.Room
@@ -38,5 +39,15 @@ defmodule Harmony.Chat do
     |> order_by([m], asc: :inserted_at, asc: :id)
     |> preload(:user)
     |> Repo.all()
+  end
+
+  def change_message(message, attrs \\ %{}) do
+    Message.changeset(message, attrs)
+  end
+
+  def create_message(%User{} = user, %Room{} = room, attrs) do
+    %Message{user: user, room: room}
+    |> Message.changeset(attrs)
+    |> Repo.insert()
   end
 end

--- a/lib/harmony/chat/message.ex
+++ b/lib/harmony/chat/message.ex
@@ -1,0 +1,23 @@
+defmodule Harmony.Chat.Message do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Harmony.Chat.Room
+  alias Harmony.Accounts.User
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "messages" do
+    field :body, :string
+    belongs_to :user, User
+    belongs_to :room, Room
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(message, attrs) do
+    message
+    |> cast(attrs, [:body])
+    |> validate_required([:body])
+  end
+end

--- a/lib/harmony/chat/room.ex
+++ b/lib/harmony/chat/room.ex
@@ -2,11 +2,15 @@ defmodule Harmony.Chat.Room do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Harmony.Chat.Message
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "rooms" do
     field :name, :string
     field :topic, :string
+
+    has_many :messages, Message
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/harmony_web.ex
+++ b/lib/harmony_web.ex
@@ -91,6 +91,7 @@ defmodule HarmonyWeb do
       import HarmonyWeb.CoreComponents
       # Chat.Room Components
       import HarmonyWeb.RoomComponents
+      import HarmonyWeb.MessageComponents
 
       # Shortcut for generating JS commands
       alias Phoenix.LiveView.JS

--- a/lib/harmony_web/components/message_components.ex
+++ b/lib/harmony_web/components/message_components.ex
@@ -1,0 +1,33 @@
+defmodule HarmonyWeb.MessageComponents do
+  @moduledoc """
+  Provides UI components for Chat.Room.
+  """
+  use Phoenix.Component
+  use Gettext, backend: HarmonyWeb.Gettext
+  use HarmonyWeb, :verified_routes
+
+  # import HarmonyWeb.CoreComponents
+
+  alias Harmony.Chat.Message
+  # alias Phoenix.LiveView.JS
+
+  attr :message, Message, required: true
+
+  def message_item(assigns) do
+    ~H"""
+    <div class="relative flex px-4 py-3">
+      <div class="h-10 w-10 rounded shrink-0 bg-slate-300"></div>
+
+      <div class="ml-2">
+        <div class="-mt-1">
+          <.link class="text-sm font-semibold hover:underline">
+            <span class="message-user">{@message.user.email}</span>
+          </.link>
+
+          <p class="text-sm message-body">{@message.body}</p>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/harmony_web/components/message_components.ex
+++ b/lib/harmony_web/components/message_components.ex
@@ -12,10 +12,11 @@ defmodule HarmonyWeb.MessageComponents do
   # alias Phoenix.LiveView.JS
 
   attr :message, Message, required: true
+  attr :dom_id, :string
 
   def message_item(assigns) do
     ~H"""
-    <div class="relative flex px-4 py-3">
+    <div id={@dom_id} class="relative flex px-4 py-3">
       <div class="h-10 w-10 rounded shrink-0 bg-slate-300"></div>
 
       <div class="ml-2">

--- a/lib/harmony_web/components/message_components.ex
+++ b/lib/harmony_web/components/message_components.ex
@@ -24,11 +24,22 @@ defmodule HarmonyWeb.MessageComponents do
           <.link class="text-sm font-semibold hover:underline">
             <span class="message-user">{@message.user.email}</span>
           </.link>
-
+          <span
+            id={@dom_id <> "timestamp"}
+            phx-hook="Timestamp"
+            data-timestamp={@message.inserted_at}
+            class="ml-1 text-xs text-gray-500"
+          >
+            {message_timestamp(@message)}
+          </span>
           <p class="text-sm message-body">{@message.body}</p>
         </div>
       </div>
     </div>
     """
+  end
+
+  defp message_timestamp(message) do
+    message.inserted_at |> Calendar.strftime("%I:%M %p on %Y/%m/%d")
   end
 end

--- a/lib/harmony_web/components/room_components.ex
+++ b/lib/harmony_web/components/room_components.ex
@@ -31,6 +31,38 @@ defmodule HarmonyWeb.RoomComponents do
     """
   end
 
+  attr :form, Ecto.Form
+  attr :room, Room
+
+  def message_send_form(assigns) do
+    ~H"""
+    <div class="h-12 bg-white px-4 pb-4">
+      <.form
+        for={@form}
+        id="message-send-form"
+        phx-submit="send-message"
+        phx-change="validate-message"
+        class="flex items-center border-2 border-slate-300 rounded-sm p-1"
+      >
+        <label for="chat-message-textarea" class="sr-only">Message Body</label>
+        <textarea
+          class="grow text-sm px-3 border-l border-slate-300 mx-1 resize-none"
+          cols=""
+          id="chat-message-textarea"
+          name={@form[:body].name}
+          placeholder={"Message ##{@room.name}"}
+          phx-hook="CtrlEnterSubmit"
+          phx-debounce
+          rows="1"
+        >{Phoenix.HTML.Form.normalize_value("textarea", @form[:body].value)}</textarea>
+        <button class="shrink flex items-center justify-center h-6 w-6 rounded hover:bg-slate-200">
+          <.icon name="hero-paper-airplane" class="h-4 w-4" />
+        </button>
+      </.form>
+    </div>
+    """
+  end
+
   attr :title, :string, default: "Rooms"
   slot :inner_block, required: true
 

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -17,6 +17,9 @@ defmodule HarmonyWeb.ChatRoomLive do
     <%= if @room do %>
       <div class="flex flex-col grow shadow-lg">
         <.room_header room={@room} hide_topic?={@hide_topic?} />
+        <div id="messages-list">
+          <.message_item :for={message <- @messages} message={message} />
+        </div>
       </div>
     <% end %>
     """
@@ -30,14 +33,16 @@ defmodule HarmonyWeb.ChatRoomLive do
 
   def handle_params(%{"name" => name}, _uri, socket) do
     room = Chat.get_room(name) || Chat.default_room()
+    messages = Chat.list_messages(room)
 
-    {:noreply, assign(socket, room: room, page_title: "##{room.name}")}
+    {:noreply, assign(socket, room: room, messages: messages, page_title: "##{room.name}")}
   end
 
   def handle_params(_params, _uri, socket) do
     case Chat.default_room() do
       room = %Chat.Room{} ->
-        {:noreply, assign(socket, room: room, page_title: "##{room.name}")}
+        messages = Chat.list_messages(room)
+        {:noreply, assign(socket, room: room, messages: messages, page_title: "##{room.name}")}
 
       nil ->
         {:noreply, assign(socket, room: nil)}

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -2,6 +2,7 @@ defmodule HarmonyWeb.ChatRoomLive do
   use HarmonyWeb, :live_view
 
   alias Harmony.Chat
+  alias Harmony.Chat.Message
 
   def render(assigns) do
     ~H"""
@@ -17,9 +18,10 @@ defmodule HarmonyWeb.ChatRoomLive do
     <%= if @room do %>
       <div class="flex flex-col grow shadow-lg">
         <.room_header room={@room} hide_topic?={@hide_topic?} />
-        <div id="messages-list">
+        <div id="messages-list" class="overflow-auto flex-grow" phx-hook="MessagesList">
           <.message_item :for={message <- @messages} message={message} />
         </div>
+        <.message_send_form form={@send_message_form} room={@room} />
       </div>
     <% end %>
     """
@@ -35,14 +37,20 @@ defmodule HarmonyWeb.ChatRoomLive do
     room = Chat.get_room(name) || Chat.default_room()
     messages = Chat.list_messages(room)
 
-    {:noreply, assign(socket, room: room, messages: messages, page_title: "##{room.name}")}
+    changeset = Chat.change_message(%Message{})
+
+    socket =
+      socket
+      |> assign(room: room, messages: messages, page_title: "##{room.name}")
+      |> assign_message_form(changeset)
+
+    {:noreply, socket}
   end
 
-  def handle_params(_params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
     case Chat.default_room() do
-      room = %Chat.Room{} ->
-        messages = Chat.list_messages(room)
-        {:noreply, assign(socket, room: room, messages: messages, page_title: "##{room.name}")}
+      %{name: name} = %Chat.Room{} ->
+        handle_params(%{"name" => name}, uri, socket)
 
       nil ->
         {:noreply, assign(socket, room: nil)}
@@ -51,5 +59,32 @@ defmodule HarmonyWeb.ChatRoomLive do
 
   def handle_event("toggle-topic", _params, socket) do
     {:noreply, update(socket, :hide_topic?, &(!&1))}
+  end
+
+  def handle_event("send-message", %{"message" => message_params}, socket) do
+    %{current_user: user, room: room} = socket.assigns
+
+    socket =
+      case Chat.create_message(user, room, message_params) do
+        {:ok, message} ->
+          socket
+          |> update(:messages, &(&1 ++ [message]))
+          |> assign_message_form(Chat.change_message(%Message{}))
+
+        {:error, changeset} ->
+          assign_message_form(socket, changeset)
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("validate-message", %{"message" => message_params}, socket) do
+    changeset = Chat.change_message(%Message{}, message_params)
+
+    {:noreply, assign_message_form(socket, changeset)}
+  end
+
+  defp assign_message_form(socket, %Ecto.Changeset{} = changeset) do
+    assign(socket, :send_message_form, to_form(changeset))
   end
 end

--- a/priv/repo/migrations/20250215211508_create_messages.exs
+++ b/priv/repo/migrations/20250215211508_create_messages.exs
@@ -1,0 +1,17 @@
+defmodule Harmony.Repo.Migrations.CreateMessages do
+  use Ecto.Migration
+
+  def change do
+    create table(:messages, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :body, :text, null: false
+      add :user_id, references(:users, on_delete: :nilify_all, type: :binary_id), null: false
+      add :room_id, references(:rooms, on_delete: :delete_all, type: :binary_id), null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:messages, [:user_id])
+    create index(:messages, [:room_id])
+  end
+end

--- a/test/harmony/chat/message_test.exs
+++ b/test/harmony/chat/message_test.exs
@@ -12,6 +12,9 @@ defmodule Harmony.Chat.MessageTest do
 
       changeset = Message.changeset(message, %{body: nil})
       refute changeset.valid?
+
+      changeset = Message.changeset(message, %{body: "hello"})
+      assert changeset.valid?
     end
   end
 end

--- a/test/harmony/chat/message_test.exs
+++ b/test/harmony/chat/message_test.exs
@@ -1,0 +1,17 @@
+defmodule Harmony.Chat.MessageTest do
+  use Harmony.DataCase, async: true
+  alias Harmony.Chat.Message
+  import Harmony.Factory
+
+  describe "Chat.Message:body" do
+    test "validates existence" do
+      message = build(:message)
+
+      changeset = Message.changeset(message, %{body: ""})
+      refute changeset.valid?
+
+      changeset = Message.changeset(message, %{body: nil})
+      refute changeset.valid?
+    end
+  end
+end

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -47,4 +47,17 @@ defmodule Harmony.ChatTest do
       assert new_room.name == "new-name"
     end
   end
+
+  describe "messages" do
+    test "list_messages/1 returns all messages for a room" do
+      room = insert(:room)
+      insert_list(3, :message, room: room)
+
+      other_room = insert(:room)
+      insert_list(3, :message, room: other_room)
+
+      messages = Chat.list_messages(room)
+      assert length(messages) == 3
+    end
+  end
 end

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -1,6 +1,7 @@
 defmodule Harmony.ChatTest do
   use Harmony.DataCase
   import Harmony.Factory
+  import Harmony.AccountsFixtures
 
   alias Harmony.Chat
 
@@ -58,6 +59,26 @@ defmodule Harmony.ChatTest do
 
       messages = Chat.list_messages(room)
       assert length(messages) == 3
+    end
+
+    test "create_message/3 create a message" do
+      user = user_fixture()
+      room = insert(:room)
+      params = params_for(:message, body: "Test message body")
+
+      {:ok, message} = Chat.create_message(user, room, params)
+      assert message.body == "Test message body"
+    end
+
+    test "change_message/2 returns a valid changeset" do
+      user = user_fixture()
+      room = insert(:room)
+      message = %Chat.Message{room: room, user: user}
+      new_attrs = %{body: "message body"}
+
+      assert changeset = %Ecto.Changeset{} = Chat.change_message(message, new_attrs)
+      assert changeset.changes.body == "message body"
+      assert changeset.valid?
     end
   end
 end

--- a/test/harmony_web/feature/user_can_see_messages_test.exs
+++ b/test/harmony_web/feature/user_can_see_messages_test.exs
@@ -1,0 +1,21 @@
+defmodule HarmonyWeb.UsersCanSeeMessages do
+  use HarmonyWeb.FeatureCase, async: true
+  import Harmony.Factory
+  import Harmony.AccountsFixtures
+
+  setup %{conn: conn} do
+    user = user_fixture()
+    room = insert(:room)
+    %{conn: log_in_user(conn, user), user: user, room: room}
+  end
+
+  test "users can see messages when in a room", %{conn: conn, room: room} do
+    [m1, m2] = insert_pair(:message, room: room)
+
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> assert_has("#messages-list .message-body", text: m1.body)
+    |> assert_has("#messages-list .message-body", text: m2.body)
+    |> assert_has("#messages-list .message-user", text: m1.user.email)
+  end
+end

--- a/test/harmony_web/feature/user_can_see_messages_test.exs
+++ b/test/harmony_web/feature/user_can_see_messages_test.exs
@@ -18,4 +18,30 @@ defmodule HarmonyWeb.UsersCanSeeMessages do
     |> assert_has("#messages-list .message-body", text: m2.body)
     |> assert_has("#messages-list .message-user", text: m1.user.email)
   end
+
+  test "each room has it's own messages", %{conn: conn, room: room} do
+    [m1, m2] = insert_pair(:message, room: room, body: "Show these messages")
+    other_room = insert(:room)
+    [om1, om2] = insert_pair(:message, room: other_room, body: "Not these messages")
+
+    conn
+    # The first room has only it's own messages
+    |> visit("/rooms/#{room.name}")
+    |> assert_has("#messages-#{m1.id}")
+    |> assert_has("#messages-#{m2.id}")
+    |> refute_has("#messages-#{om1.id}")
+    |> refute_has("#messages-#{om2.id}")
+    # The other room has only *it's* own messages
+    |> click_link(other_room.name)
+    |> assert_has("#messages-#{om1.id}")
+    |> assert_has("#messages-#{om2.id}")
+    |> refute_has("#messages-#{m1.id}")
+    |> refute_has("#messages-#{m2.id}")
+    # Now back to the first
+    |> click_link(room.name)
+    |> assert_has("#messages-#{m1.id}")
+    |> assert_has("#messages-#{m2.id}")
+    |> refute_has("#messages-#{om1.id}")
+    |> refute_has("#messages-#{om2.id}")
+  end
 end

--- a/test/harmony_web/feature/user_can_send_messages_test.exs
+++ b/test/harmony_web/feature/user_can_send_messages_test.exs
@@ -1,0 +1,20 @@
+defmodule HarmonyWeb.UsersCanSendMessages do
+  use HarmonyWeb.FeatureCase, async: true
+  import Harmony.Factory
+  import Harmony.AccountsFixtures
+
+  setup %{conn: conn} do
+    user = user_fixture()
+    room = insert(:room)
+    %{conn: log_in_user(conn, user), user: user, room: room}
+  end
+
+  test "users can send messages", %{conn: conn, user: user, room: room} do
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> fill_in("#message-send-form textarea", "Message Body", with: "Test message body")
+    |> submit()
+    |> assert_has("#messages-list .message-body", text: "Test message body")
+    |> assert_has("#messages-list .message-user", text: user.email)
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -8,4 +8,12 @@ defmodule Harmony.Factory do
       topic: sequence(:name, &"room-#{&1} is the best room around")
     }
   end
+
+  def message_factory do
+    %Harmony.Chat.Message{
+      body: "Hello",
+      user: Harmony.AccountsFixtures.user_fixture(),
+      room: build(:room)
+    }
+  end
 end


### PR DESCRIPTION
Implemented features:
* Users can see a list of messages in a room
* Users can send messages in a room
* Users see a friendly 'time ago' timestamp on messages 

Changes:
* Added `Harmony.Chat.Message` schema
* Added `message-item` and `message-list` components to the `ChatRoomLive` view
* Added `send-message-form` component to the view
* Added dynamic timestamps to the `message-items`