### PR TITLE
Users can delete their own messages

### DIFF
--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -50,4 +50,14 @@ defmodule Harmony.Chat do
     |> Message.changeset(attrs)
     |> Repo.insert()
   end
+
+  def delete_message_by_id(id, %User{id: user_id}) do
+    case Repo.get(Message, id) do
+      %Message{user_id: ^user_id} = message ->
+        Repo.delete(message)
+
+      _ ->
+        {:error, "Message does not exist or is not owned by user"}
+    end
+  end
 end

--- a/lib/harmony_web/components/message_components.ex
+++ b/lib/harmony_web/components/message_components.ex
@@ -6,17 +6,19 @@ defmodule HarmonyWeb.MessageComponents do
   use Gettext, backend: HarmonyWeb.Gettext
   use HarmonyWeb, :verified_routes
 
-  # import HarmonyWeb.CoreComponents
+  import HarmonyWeb.CoreComponents
 
   alias Harmony.Chat.Message
   # alias Phoenix.LiveView.JS
 
   attr :message, Message, required: true
+  attr :show_delete, :boolean, default: false
   attr :dom_id, :string
 
   def message_item(assigns) do
     ~H"""
-    <div id={@dom_id} class="relative flex px-4 py-3">
+    <div id={@dom_id} class="group relative flex px-4 py-3">
+      <.message_delete_button :if={@show_delete} message={@message} />
       <div class="h-10 w-10 rounded shrink-0 bg-slate-300"></div>
 
       <div class="ml-2">
@@ -36,6 +38,22 @@ defmodule HarmonyWeb.MessageComponents do
         </div>
       </div>
     </div>
+    """
+  end
+
+  attr :message, Message, required: true
+
+  defp message_delete_button(assigns) do
+    ~H"""
+    <button
+      phx-click="delete-message"
+      phx-value-id={@message.id}
+      data-confirm="Are you sure?"
+      class="absolute top-4 right-4 text-red-500 hover:text-red-800 cursor-pointer hidden group-hover:block"
+    >
+      <.icon name="hero-trash" class="h-4 w-4" />
+      <div class="sr-only">Delete</div>
+    </button>
     """
   end
 

--- a/lib/harmony_web/components/message_components.ex
+++ b/lib/harmony_web/components/message_components.ex
@@ -17,7 +17,7 @@ defmodule HarmonyWeb.MessageComponents do
 
   def message_item(assigns) do
     ~H"""
-    <div id={@dom_id} class="group relative flex px-4 py-3">
+    <div id={@dom_id} class="group relative flex px-4 py-3 hover:bg-slate-100">
       <.message_delete_button :if={@show_delete} message={@message} />
       <div class="h-10 w-10 rounded shrink-0 bg-slate-300"></div>
 

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -28,6 +28,7 @@ defmodule HarmonyWeb.ChatRoomLive do
             :for={{dom_id, message} <- @streams.messages}
             dom_id={dom_id}
             message={message}
+            show_delete={@current_user == message.user}
           />
         </div>
         <.message_send_form form={@send_message_form} room={@room} />
@@ -86,6 +87,11 @@ defmodule HarmonyWeb.ChatRoomLive do
       end
 
     {:noreply, socket}
+  end
+
+  def handle_event("delete-message", %{"id" => id}, socket) do
+    {:ok, message} = Chat.delete_message_by_id(id, socket.assigns.current_user)
+    {:noreply, stream_delete(socket, :messages, message)}
   end
 
   def handle_event("validate-message", %{"message" => message_params}, socket) do

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -80,5 +80,27 @@ defmodule Harmony.ChatTest do
       assert changeset.changes.body == "message body"
       assert changeset.valid?
     end
+
+    test "delete_message_by_id/2 delete a message with id && user" do
+      user = user_fixture()
+      room = insert(:room)
+      message = insert(:message, user: user, room: room)
+      id = message.id
+
+      assert [%Chat.Message{id: ^id}] = Chat.list_messages(room)
+      assert {:ok, %Chat.Message{}} = Chat.delete_message_by_id(message.id, user)
+      assert [] == Chat.list_messages(room)
+    end
+
+    test "delete_message_by_id/2 does not delete a message with wrong user" do
+      user = user_fixture()
+      room = insert(:room)
+      message = insert(:message, room: room)
+      id = message.id
+
+      assert [%Chat.Message{id: ^id}] = Chat.list_messages(room)
+      assert {:error, _} = Chat.delete_message_by_id(message.id, user)
+      assert [%Chat.Message{id: ^id}] = Chat.list_messages(room)
+    end
   end
 end

--- a/test/harmony_web/feature/user_can_delete_messages_test.exs
+++ b/test/harmony_web/feature/user_can_delete_messages_test.exs
@@ -1,0 +1,34 @@
+defmodule HarmonyWeb.UsersCanDeleteMessages do
+  use HarmonyWeb.FeatureCase, async: true
+  import Harmony.Factory
+  import Harmony.AccountsFixtures
+
+  setup %{conn: conn} do
+    user = user_fixture()
+    room = insert(:room)
+    %{conn: log_in_user(conn, user), user: user, room: room}
+  end
+
+  @tag focus: true
+  test "users can delete their own messages", %{conn: conn, room: room, user: user} do
+    [m1, m2] = insert_pair(:message, room: room, user: user)
+
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> assert_has("#messages-#{m1.id}")
+    |> assert_has("#messages-#{m2.id}")
+    |> click_button("#messages-#{m1.id} button", "Delete")
+    |> refute_has("#messages-#{m1.id}")
+    |> assert_has("#messages-#{m2.id}")
+  end
+
+  @tag focus: true
+  test "users can't delete others' messages", %{conn: conn, room: room} do
+    m = insert(:message, room: room)
+
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> assert_has("#messages-#{m.id}")
+    |> refute_has("#messages-#{m.id} button")
+  end
+end

--- a/test/harmony_web/feature/user_can_edit_their_username_test.exs
+++ b/test/harmony_web/feature/user_can_edit_their_username_test.exs
@@ -4,7 +4,6 @@ defmodule HarmonyWeb.UserEditTheirUsername do
 
   setup :register_and_log_in_user
 
-  @tag focus: true
   test "user can edit their username", %{conn: conn, user: user} do
     conn
     |> visit(~p"/users/settings")


### PR DESCRIPTION
Users should be able to delete their own messages.

When the user mouses over a message they wrote, a delete icon should appear.
Clicking on the delete icon should show a confirmation dialog. Clicking to
confirm should delete the message.

Users should not be able to delete other users' messages, so they should not see
delete icons for other users' messages either.
