### PR TITLE
feature/users can see each others messages

### DIFF
--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -3,6 +3,8 @@ defmodule Harmony.Chat do
   alias Harmony.Accounts.User
   import Ecto.Query
 
+  @pubsub Harmony.PubSub
+
   # Chat.Room
 
   def list_rooms do
@@ -31,6 +33,14 @@ defmodule Harmony.Chat do
     |> Repo.update()
   end
 
+  def subscribe_to_room(room) do
+    Phoenix.PubSub.subscribe(@pubsub, topic(room.id))
+  end
+
+  def unsubscribe_from_room(room) do
+    Phoenix.PubSub.unsubscribe(@pubsub, topic(room.id))
+  end
+
   # Chat.Message
 
   def list_messages(%Room{id: room_id}) do
@@ -46,9 +56,13 @@ defmodule Harmony.Chat do
   end
 
   def create_message(%User{} = user, %Room{} = room, attrs) do
-    %Message{user: user, room: room}
-    |> Message.changeset(attrs)
-    |> Repo.insert()
+    with {:ok, message} <-
+           %Message{user: user, room: room}
+           |> Message.changeset(attrs)
+           |> Repo.insert() do
+      Phoenix.PubSub.broadcast!(@pubsub, topic(room.id), {:new_message, message})
+      {:ok, message}
+    end
   end
 
   def delete_message_by_id(id, %User{id: user_id}) do
@@ -60,4 +74,6 @@ defmodule Harmony.Chat do
         {:error, "Message does not exist or is not owned by user"}
     end
   end
+
+  defp topic(room_id), do: "chat_room:#{room_id}"
 end

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -68,6 +68,7 @@ defmodule Harmony.Chat do
   def delete_message_by_id(id, %User{id: user_id}) do
     case Repo.get(Message, id) do
       %Message{user_id: ^user_id} = message ->
+        Phoenix.PubSub.broadcast!(@pubsub, topic(message.room_id), {:delete_message, message})
         Repo.delete(message)
 
       _ ->

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -80,6 +80,14 @@ defmodule HarmonyWeb.ChatRoomLive do
     {:noreply, socket}
   end
 
+  def handle_info({:delete_message, message}, socket) do
+    socket =
+      socket
+      |> stream_delete(:messages, message)
+
+    {:noreply, socket}
+  end
+
   def handle_event("toggle-topic", _params, socket) do
     {:noreply, update(socket, :hide_topic?, &(!&1))}
   end
@@ -101,8 +109,8 @@ defmodule HarmonyWeb.ChatRoomLive do
   end
 
   def handle_event("delete-message", %{"id" => id}, socket) do
-    {:ok, message} = Chat.delete_message_by_id(id, socket.assigns.current_user)
-    {:noreply, stream_delete(socket, :messages, message)}
+    {:ok, %Chat.Message{}} = Chat.delete_message_by_id(id, socket.assigns.current_user)
+    {:noreply, socket}
   end
 
   def handle_event("validate-message", %{"message" => message_params}, socket) do

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -65,8 +65,10 @@ defmodule Harmony.ChatTest do
       user = user_fixture()
       room = insert(:room)
       params = params_for(:message, body: "Test message body")
+      Chat.subscribe_to_room(room)
 
       {:ok, message} = Chat.create_message(user, room, params)
+      assert_receive({:new_message, ^message})
       assert message.body == "Test message body"
     end
 
@@ -86,9 +88,11 @@ defmodule Harmony.ChatTest do
       room = insert(:room)
       message = insert(:message, user: user, room: room)
       id = message.id
+      Chat.subscribe_to_room(room)
 
       assert [%Chat.Message{id: ^id}] = Chat.list_messages(room)
       assert {:ok, %Chat.Message{}} = Chat.delete_message_by_id(message.id, user)
+      assert_receive({:delete_message, %Chat.Message{id: ^id}})
       assert [] == Chat.list_messages(room)
     end
 
@@ -97,9 +101,11 @@ defmodule Harmony.ChatTest do
       room = insert(:room)
       message = insert(:message, room: room)
       id = message.id
+      Chat.subscribe_to_room(room)
 
       assert [%Chat.Message{id: ^id}] = Chat.list_messages(room)
       assert {:error, _} = Chat.delete_message_by_id(message.id, user)
+      refute_receive({:delete_message, %Chat.Message{id: ^id}})
       assert [%Chat.Message{id: ^id}] = Chat.list_messages(room)
     end
   end


### PR DESCRIPTION
Putting the "Live" in the LiveView finally.

    ChatRoomLive subscribes/unsubscribes from topics chat_room:roomid
    Chat.create_message/3 broadcasts {:new_message}
    Chat.delete_message_by_id/2 broadcasts {:delete_message

I'm marking this as the first milestone v0.1, since it's now functional for chatting.
Clearly, more functionality is needed for administrative features (such as
creating rooms, assigning admin roles to other users, moderating the chat rooms,
etc).

Redoing this PR because I unintentionally overwrote the merge from the last
go-around.
