### PR TITLE
feature/users can see each others online status

### DIFF
--- a/lib/harmony/accounts.ex
+++ b/lib/harmony/accounts.ex
@@ -401,4 +401,15 @@ defmodule Harmony.Accounts do
       {:error, :user, changeset, _} -> {:error, changeset}
     end
   end
+
+  @doc """
+  Returns a list of all users
+
+  ## Examples
+      iex> list_users()
+      [%User{}, %User{}]
+  """
+  def list_users() do
+    Repo.all(from u in User, order_by: [asc: u.username])
+  end
 end

--- a/lib/harmony/application.ex
+++ b/lib/harmony/application.ex
@@ -16,6 +16,7 @@ defmodule Harmony.Application do
       {Finch, name: Harmony.Finch},
       # Start a worker by calling: Harmony.Worker.start_link(arg)
       # {Harmony.Worker, arg},
+      HarmonyWeb.Presence,
       # Start to serve requests, typically the last entry
       HarmonyWeb.Endpoint
     ]

--- a/lib/harmony_web.ex
+++ b/lib/harmony_web.ex
@@ -96,6 +96,7 @@ defmodule HarmonyWeb do
       # Chat.Room Components
       import HarmonyWeb.RoomComponents
       import HarmonyWeb.MessageComponents
+      import HarmonyWeb.UserComponents
 
       # Shortcut for generating JS commands
       alias Phoenix.LiveView.JS

--- a/lib/harmony_web/channels/presence.ex
+++ b/lib/harmony_web/channels/presence.ex
@@ -1,0 +1,11 @@
+defmodule HarmonyWeb.Presence do
+  @moduledoc """
+  Provides presence tracking to channels and processes.
+
+  See the [`Phoenix.Presence`](https://hexdocs.pm/phoenix/Phoenix.Presence.html)
+  docs for more details.
+  """
+  use Phoenix.Presence,
+    otp_app: :harmony,
+    pubsub_server: Harmony.PubSub
+end

--- a/lib/harmony_web/components/user_components.ex
+++ b/lib/harmony_web/components/user_components.ex
@@ -4,6 +4,7 @@ defmodule HarmonyWeb.UserComponents do
   use HarmonyWeb, :verified_routes
 
   alias Harmony.Accounts.User
+  alias HarmonyWeb.OnlineUsers
 
   attr :user, User, required: true
   attr :online, :boolean, default: false
@@ -11,12 +12,16 @@ defmodule HarmonyWeb.UserComponents do
   def user(assigns) do
     ~H"""
     <div>
-      <.link class="flex items-center h-8 hover:bg-gray-300 text-sm pl-8 pr-3" href="#">
+      <.link
+        class="flex items-center h-8 hover:bg-gray-300 text-sm pl-8 pr-3"
+        href="#"
+        data-userstatus-for={@user.id}
+      >
         <div class="flex justify-center w-4">
           <%= if @online do %>
-            <span class="w-2 h-2 rounded-full bg-blue-500"></span>
+            <span class="w-2 h-2 rounded-full bg-blue-500" data-online="online"></span>
           <% else %>
-            <span class="w-2 h-2 rounded-full border-2 border-gray-500"></span>
+            <span class="w-2 h-2 rounded-full border-2 border-gray-500" data-online="offline"></span>
           <% end %>
         </div>
 
@@ -27,6 +32,7 @@ defmodule HarmonyWeb.UserComponents do
   end
 
   attr :users, :any, default: []
+  attr :online_users, :map, default: %{}
 
   def users_list(assigns) do
     ~H"""
@@ -38,7 +44,7 @@ defmodule HarmonyWeb.UserComponents do
       </div>
 
       <div id="users-list">
-        <.user :for={user <- @users} user={user} />
+        <.user :for={user <- @users} user={user} online={OnlineUsers.online?(@online_users, user.id)} />
       </div>
     </div>
     """

--- a/lib/harmony_web/components/user_components.ex
+++ b/lib/harmony_web/components/user_components.ex
@@ -1,0 +1,46 @@
+defmodule HarmonyWeb.UserComponents do
+  use Phoenix.Component
+  use Gettext, backend: HarmonyWeb.Gettext
+  use HarmonyWeb, :verified_routes
+
+  alias Harmony.Accounts.User
+
+  attr :user, User, required: true
+  attr :online, :boolean, default: false
+
+  def user(assigns) do
+    ~H"""
+    <div>
+      <.link class="flex items-center h-8 hover:bg-gray-300 text-sm pl-8 pr-3" href="#">
+        <div class="flex justify-center w-4">
+          <%= if @online do %>
+            <span class="w-2 h-2 rounded-full bg-blue-500"></span>
+          <% else %>
+            <span class="w-2 h-2 rounded-full border-2 border-gray-500"></span>
+          <% end %>
+        </div>
+
+        <span class="ml-2 leading-none">{@user.username}</span>
+      </.link>
+    </div>
+    """
+  end
+
+  attr :users, :any, default: []
+
+  def users_list(assigns) do
+    ~H"""
+    <div class="mt-4 grow">
+      <div class="flex items-center h-8 px-3">
+        <div class="flex items-center grow">
+          <span class="ml-2 leading-none font-medium text-sm">Users</span>
+        </div>
+      </div>
+
+      <div id="users-list">
+        <.user :for={user <- @users} user={user} />
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -1,6 +1,7 @@
 defmodule HarmonyWeb.ChatRoomLive do
   use HarmonyWeb, :live_view
 
+  alias Harmony.Accounts
   alias Harmony.Chat
   alias Harmony.Chat.Message
   alias HarmonyWeb.Components.RoomEditComponent
@@ -13,12 +14,10 @@ defmodule HarmonyWeb.ChatRoomLive do
       <.rooms_list title="Rooms">
         <.rooms_list_item :for={room <- @rooms} room={room} active={room.id == @room.id} />
       </.rooms_list>
-
-      <.rooms_list_actions current_user={@current_user} />
     </div>
 
-    <%= if @room do %>
-      <div class="flex flex-col grow shadow-lg">
+    <div class="flex flex-col grow shadow-lg">
+      <%= if @room do %>
         <.room_header is_admin={is_admin(@current_user)} room={@room} hide_topic?={@hide_topic?} />
         <div
           id="messages-list"
@@ -34,10 +33,17 @@ defmodule HarmonyWeb.ChatRoomLive do
           />
         </div>
         <.message_send_form form={@send_message_form} room={@room} />
-      </div>
-    <% end %>
+      <% end %>
+    </div>
+
+    <div class="flex flex-col shrink-0 w-64 bg-slate-100 push-right">
+      <.users_list users={@users} />
+
+      <.rooms_list_actions current_user={@current_user} />
+    </div>
 
     <%= if @current_user.role == :admin do %>
+      <!-- Room modals -->
       <.live_component module={RoomNewComponent} id="new-room-component" current_user={@current_user} />
       <%= if @room do %>
         <.live_component
@@ -53,9 +59,11 @@ defmodule HarmonyWeb.ChatRoomLive do
 
   def mount(_params, _session, socket) do
     rooms = Chat.list_rooms()
+    users = Accounts.list_users()
 
     socket
     |> assign(rooms: rooms, hide_topic?: false)
+    |> assign(users: users)
     |> ok
   end
 

--- a/lib/harmony_web/online_users.ex
+++ b/lib/harmony_web/online_users.ex
@@ -1,0 +1,27 @@
+defmodule HarmonyWeb.OnlineUsers do
+  alias HarmonyWeb.Presence
+
+  @topic "online_users"
+
+  def list() do
+    @topic
+    |> Presence.list()
+    |> Enum.into(
+      %{},
+      fn {user_id, %{metas: connections}} -> {user_id, length(connections)} end
+    )
+  end
+
+  def track(pid, user) do
+    {:ok, _ref} = Presence.track(pid, @topic, user.id, %{})
+    :ok
+  end
+
+  def online?(online_users, user_id) do
+    Map.get(online_users, user_id, 0) > 0
+  end
+
+  def subscribe() do
+    Phoenix.PubSub.subscribe(Harmony.PubSub, @topic)
+  end
+end

--- a/test/harmony/accounts_test.exs
+++ b/test/harmony/accounts_test.exs
@@ -530,4 +530,14 @@ defmodule Harmony.AccountsTest do
       refute inspect(%User{password: "123456"}) =~ "password: \"123456\""
     end
   end
+
+  describe "list_users/0" do
+    test "lists all of the users" do
+      u1 = user_fixture()
+      u2 = user_fixture()
+
+      assert u1 in Accounts.list_users()
+      assert u2 in Accounts.list_users()
+    end
+  end
 end

--- a/test/harmony_web/feature/user_can_see_each_others_online_status_test.exs
+++ b/test/harmony_web/feature/user_can_see_each_others_online_status_test.exs
@@ -1,0 +1,45 @@
+defmodule HarmonyWeb.UsersCanSeeEachOthersOnlineStatusTest do
+  use HarmonyWeb.FeatureCase, async: true
+  import Harmony.Factory
+  import Harmony.AccountsFixtures
+
+  setup %{conn: conn} do
+    room = insert(:room)
+    %{conn: conn, room: room}
+  end
+
+  @tag focus: true
+  test "users can see each other's online status", %{conn: conn, room: room} do
+    user1 = user_fixture()
+    user2 = user_fixture()
+
+    session1 =
+      conn
+      |> log_in_user(user1)
+      |> visit("/rooms/#{room.name}")
+      |> assert_user_status(user1.id, "online")
+      |> assert_user_status(user2.id, "offline")
+
+    # in a separate browser
+    session2 =
+      conn
+      |> log_in_user(user2)
+      |> visit("/rooms/#{room.name}")
+      |> assert_user_status(user1.id, "online")
+      |> assert_user_status(user2.id, "online")
+
+    # back to the first
+    session1
+    |> click_link("Log out")
+
+    # and back to the second
+    session2
+    |> assert_user_status(user1.id, "offline")
+    |> assert_user_status(user2.id, "online")
+  end
+
+  defp assert_user_status(session, user_id, status) do
+    session
+    |> assert_has("[data-userstatus-for='#{user_id}'] [data-online='#{status}']")
+  end
+end

--- a/test/harmony_web/online_users_test.exs
+++ b/test/harmony_web/online_users_test.exs
@@ -1,0 +1,39 @@
+defmodule HarmonyWeb.OnlineUsersTest do
+  use Harmony.DataCase, async: true
+
+  alias HarmonyWeb.OnlineUsers
+
+  import Harmony.AccountsFixtures
+
+  describe "list/0" do
+    test "is an empty map with nobody tracked" do
+      assert OnlineUsers.list() == %{}
+    end
+
+    test "returns the count of users" do
+      user1 = user_fixture()
+      OnlineUsers.track(self(), user1)
+
+      assert OnlineUsers.list() == %{user1.id => 1}
+    end
+  end
+
+  describe "online?/2" do
+    test "returns false if offline" do
+      user1 = user_fixture()
+      user2 = user_fixture()
+
+      refute OnlineUsers.online?(OnlineUsers.list(), user1.id)
+      refute OnlineUsers.online?(OnlineUsers.list(), user2.id)
+    end
+
+    test "returns true if online" do
+      user1 = user_fixture()
+      user2 = user_fixture()
+      OnlineUsers.track(self(), user1)
+
+      assert OnlineUsers.online?(OnlineUsers.list(), user1.id)
+      refute OnlineUsers.online?(OnlineUsers.list(), user2.id)
+    end
+  end
+end


### PR DESCRIPTION
Users can see each others' online status.

This implements a basic `Phoenix.Presence` implementation. The module
`HarmonyWeb.OnlineUsers` with the following functions:

- `list/0` returns a map of `user_id`s to a count of that `User`s logins
- `online?/2` takes the previous list and a `user_id`, and returns a boolean
- `track/2` takes the `pid` to track, along with the `User` and returns `:ok`
- 'subscribe/0` subscribes to the `PubSub` for change notification
