### PR TITLE
feature/users have room memberships

### DIFF
--- a/lib/harmony/accounts/user.ex
+++ b/lib/harmony/accounts/user.ex
@@ -2,7 +2,7 @@ defmodule Harmony.Accounts.User do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Harmony.Chat.{Room, RoomMemberships}
+  alias Harmony.Chat.{Room, RoomMembership}
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -15,7 +15,7 @@ defmodule Harmony.Accounts.User do
     field :current_password, :string, virtual: true, redact: true
     field :confirmed_at, :utc_datetime
 
-    many_to_many :rooms, Room, join_through: RoomMemberships
+    many_to_many :rooms, Room, join_through: RoomMembership
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/harmony/accounts/user.ex
+++ b/lib/harmony/accounts/user.ex
@@ -1,6 +1,9 @@
 defmodule Harmony.Accounts.User do
   use Ecto.Schema
   import Ecto.Changeset
+
+  alias Harmony.Chat.{Room, RoomMemberships}
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "users" do
@@ -11,6 +14,8 @@ defmodule Harmony.Accounts.User do
     field :hashed_password, :string, redact: true
     field :current_password, :string, virtual: true, redact: true
     field :confirmed_at, :utc_datetime
+
+    many_to_many :rooms, Room, join_through: RoomMemberships
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -70,6 +70,13 @@ defmodule Harmony.Chat do
     |> Repo.insert!()
   end
 
+  def list_joined_rooms(%User{} = user) do
+    user
+    |> Repo.preload(:rooms)
+    |> Map.fetch!(:rooms)
+    |> Enum.sort_by(& &1.name)
+  end
+
   # Chat.Message
 
   def list_messages(%Room{id: room_id}) do

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -85,6 +85,17 @@ defmodule Harmony.Chat do
     )
   end
 
+  def list_rooms_with_joined(%User{} = user) do
+    query =
+      from room in Room,
+        left_join: membership in RoomMembership,
+        on: room.id == membership.room_id and ^user.id == membership.user_id,
+        select: {room, not is_nil(membership.id)},
+        order_by: [asc: room.name]
+
+    Repo.all(query)
+  end
+
   def toggle_room_membership(%Room{} = room, %User{} = user) do
     case Repo.get_by(RoomMembership, room_id: room.id, user_id: user.id) do
       %RoomMembership{} = membership ->

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -85,6 +85,18 @@ defmodule Harmony.Chat do
     )
   end
 
+  def toggle_room_membership(%Room{} = room, %User{} = user) do
+    case Repo.get_by(RoomMembership, room_id: room.id, user_id: user.id) do
+      %RoomMembership{} = membership ->
+        Repo.delete(membership)
+        {room, false}
+
+      nil ->
+        join_room!(room, user)
+        {room, true}
+    end
+  end
+
   # Chat.Message
 
   def list_messages(%Room{id: room_id}) do

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -1,6 +1,8 @@
 defmodule Harmony.Chat do
-  alias Harmony.{Chat.Room, Chat.Message, Repo}
+  alias Harmony.Repo
   alias Harmony.Accounts.User
+  alias Harmony.Chat.{Message, Room, RoomMembership}
+
   import Ecto.Query
 
   @pubsub Harmony.PubSub
@@ -61,6 +63,11 @@ defmodule Harmony.Chat do
 
   def unsubscribe_from_room(room) do
     Phoenix.PubSub.unsubscribe(@pubsub, topic(room.id))
+  end
+
+  def join_room!(%Room{} = room, %User{} = user) do
+    %RoomMembership{room: room, user: user}
+    |> Repo.insert!()
   end
 
   # Chat.Message

--- a/lib/harmony/chat/room.ex
+++ b/lib/harmony/chat/room.ex
@@ -3,7 +3,7 @@ defmodule Harmony.Chat.Room do
   import Ecto.Changeset
 
   alias Harmony.Accounts.User
-  alias Harmony.Chat.{Message, RoomMemberships}
+  alias Harmony.Chat.{Message, RoomMembership}
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -12,7 +12,7 @@ defmodule Harmony.Chat.Room do
     field :topic, :string
 
     has_many :messages, Message
-    many_to_many :members, User, join_through: RoomMemberships
+    many_to_many :members, User, join_through: RoomMembership
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/harmony/chat/room.ex
+++ b/lib/harmony/chat/room.ex
@@ -2,7 +2,8 @@ defmodule Harmony.Chat.Room do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Harmony.Chat.Message
+  alias Harmony.Accounts.User
+  alias Harmony.Chat.{Message, RoomMemberships}
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -11,6 +12,7 @@ defmodule Harmony.Chat.Room do
     field :topic, :string
 
     has_many :messages, Message
+    many_to_many :members, User, join_through: RoomMemberships
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/harmony/chat/room_membership.ex
+++ b/lib/harmony/chat/room_membership.ex
@@ -1,0 +1,24 @@
+defmodule Harmony.Chat.RoomMembership do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Harmony.Accounts.User
+  alias Harmony.Chat.Room
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "room_memberships" do
+    belongs_to :room, Room
+    belongs_to :user, User
+    field :last_read_id, Ecto.UUID
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(room_memberships, attrs) do
+    room_memberships
+    |> cast(attrs, [:last_read_id])
+    |> validate_required([:last_read_id])
+  end
+end

--- a/lib/harmony_web/components/live/room_index_component.ex
+++ b/lib/harmony_web/components/live/room_index_component.ex
@@ -1,0 +1,47 @@
+defmodule HarmonyWeb.Components.RoomIndexComponent do
+  use HarmonyWeb, :live_component
+
+  alias Harmony.Chat
+
+  def render(assigns) do
+    ~H"""
+    <div id="room-index">
+      <.modal id="index-room-modal">
+        <.header>Browsing rooms</.header>
+        <div>
+          <.link
+            :for={room <- @rooms}
+            phx-click="join-room"
+            phx-target={@myself}
+            phx-value-room={room.name}
+            class="flex items-center h-8 text-sm pl-8 pr-3 hover:bg-slate-300"
+          >
+            <.icon name="hero-hashtag" />
+            <span class="ml-2 leading-none">
+              {room.name}
+            </span>
+          </.link>
+        </div>
+      </.modal>
+    </div>
+    """
+  end
+
+  def mount(socket) do
+    rooms = Chat.list_rooms()
+
+    socket
+    |> assign(rooms: rooms)
+    |> ok
+  end
+
+  def handle_event("join-room", %{"room" => room_name}, socket) do
+    room = Chat.get_room(room_name)
+    Chat.join_room!(room, socket.assigns.current_user)
+    send(self(), {:joined_room, room})
+
+    socket
+    |> put_flash(:info, "You have joined ##{room.name}")
+    |> noreply
+  end
+end

--- a/lib/harmony_web/components/live/room_index_component.ex
+++ b/lib/harmony_web/components/live/room_index_component.ex
@@ -5,22 +5,40 @@ defmodule HarmonyWeb.Components.RoomIndexComponent do
 
   def render(assigns) do
     ~H"""
-    <div id="room-index">
+    <div>
       <.modal id="index-room-modal">
         <.header>Browsing rooms</.header>
-        <div>
-          <.link
-            :for={room <- @rooms}
-            phx-click="toggle-room"
-            phx-target={@myself}
-            phx-value-room={room.name}
-            class="flex items-center h-8 text-sm pl-8 pr-3 hover:bg-slate-300"
+        <div id="room-index" phx-update="stream">
+          <div
+            :for={{id, {room, joined?}} <- @streams.rooms}
+            id={id}
+            phx-click={JS.patch("/rooms/#{room.name}")}
+            class="room-index-item flex items-center h-10 text-sm pl-8 pr-3 hover:bg-slate-300 group"
           >
             <.icon name="hero-hashtag" />
-            <span class="ml-2 leading-none">
-              {room.name}
-            </span>
-          </.link>
+            <div class="grow">
+              <div class="ml-2 leading-none block text-lg">
+                {room.name}
+              </div>
+              <div class="ml-2 leading-none block">
+                <span :if={joined?} class="text-green-600 font-bold">Joined</span>
+                <span :if={joined?} class="mx-1">·</span>
+                <span class="text-gray-600 font-light">{room.topic}</span>
+              </div>
+            </div>
+            <button
+              class="hidden group-hover:block rounded-sm hover:bg-zinc-100 py-1 px-2 text-sm font-semibold border border-zinc-400"
+              phx-click="toggle-room"
+              phx-target={@myself}
+              phx-value-room={room.name}
+            >
+              <%= if joined? do %>
+                Leave
+              <% else %>
+                Join
+              <% end %>
+            </button>
+          </div>
         </div>
       </.modal>
     </div>
@@ -28,19 +46,27 @@ defmodule HarmonyWeb.Components.RoomIndexComponent do
   end
 
   def mount(socket) do
-    rooms = Chat.list_rooms()
+    socket
+    |> ok
+  end
+
+  def update(assigns, socket) do
+    rooms = Chat.list_rooms_with_joined(assigns.current_user)
 
     socket
-    |> assign(rooms: rooms)
+    |> assign(assigns)
+    |> stream_configure(:rooms, dom_id: fn {r, _} -> "room-index-item-#{r.id}" end)
+    |> stream(:rooms, rooms)
     |> ok
   end
 
   def handle_event("toggle-room", %{"room" => room_name}, socket) do
     room = Chat.get_room(room_name)
-    Chat.toggle_room_membership(room, socket.assigns.current_user)
+    {room, joined?} = Chat.toggle_room_membership(room, socket.assigns.current_user)
     send(self(), {:joined_room, room})
 
     socket
+    |> stream_insert(:rooms, {room, joined?})
     |> put_flash(:info, "You have joined ##{room.name}")
     |> noreply
   end

--- a/lib/harmony_web/components/live/room_index_component.ex
+++ b/lib/harmony_web/components/live/room_index_component.ex
@@ -11,7 +11,7 @@ defmodule HarmonyWeb.Components.RoomIndexComponent do
         <div>
           <.link
             :for={room <- @rooms}
-            phx-click="join-room"
+            phx-click="toggle-room"
             phx-target={@myself}
             phx-value-room={room.name}
             class="flex items-center h-8 text-sm pl-8 pr-3 hover:bg-slate-300"
@@ -35,9 +35,9 @@ defmodule HarmonyWeb.Components.RoomIndexComponent do
     |> ok
   end
 
-  def handle_event("join-room", %{"room" => room_name}, socket) do
+  def handle_event("toggle-room", %{"room" => room_name}, socket) do
     room = Chat.get_room(room_name)
-    Chat.join_room!(room, socket.assigns.current_user)
+    Chat.toggle_room_membership(room, socket.assigns.current_user)
     send(self(), {:joined_room, room})
 
     socket

--- a/lib/harmony_web/components/room_components.ex
+++ b/lib/harmony_web/components/room_components.ex
@@ -31,6 +31,24 @@ defmodule HarmonyWeb.RoomComponents do
     """
   end
 
+  attr :icon, :string, required: true
+  attr :title, :string, required: true
+  attr :on_click, :any
+
+  def rooms_list_xitem(assigns) do
+    ~H"""
+    <.link
+      phx-click={@on_click}
+      class="rooms-list-item flex items-center h-8 text-sm pl-8 pr-3 hover:bg-slate-300"
+    >
+      <.icon name={"hero-" <> @icon} class="h-4 w-4" />
+      <span class="ml-2 leading-none name">
+        {@title}
+      </span>
+    </.link>
+    """
+  end
+
   attr :form, Ecto.Form
   attr :room, Room
 

--- a/lib/harmony_web/components/room_components.ex
+++ b/lib/harmony_web/components/room_components.ex
@@ -147,42 +147,6 @@ defmodule HarmonyWeb.RoomComponents do
     """
   end
 
-  attr :current_user, Harmony.Accounts.User
-  slot :inner_block, required: false
-
-  def rooms_list_actions(assigns) do
-    ~H"""
-    <ul class="relative z-10 flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end bg-slate-300 py-2">
-      <li class="text-[0.8125rem] leading-6 text-zinc-900">
-        {@current_user.username}
-      </li>
-
-      <li>
-        <.link
-          href={~p"/users/settings"}
-          title="Settings"
-          class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
-        >
-          <.icon name="hero-user-circle" />
-          <div class="sr-only">Settings</div>
-        </.link>
-      </li>
-
-      <li>
-        <.link
-          href={~p"/users/log_out"}
-          method="delete"
-          title="Log out"
-          class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
-        >
-          <.icon name="hero-arrow-right-start-on-rectangle" />
-          <div class="sr-only">Log out</div>
-        </.link>
-      </li>
-    </ul>
-    """
-  end
-
   attr :id, :string, default: "new-room-form"
   attr :title, :string, default: "New chat room"
   attr :for, Phoenix.HTML.Form, required: true

--- a/lib/harmony_web/components/user_components.ex
+++ b/lib/harmony_web/components/user_components.ex
@@ -3,6 +3,8 @@ defmodule HarmonyWeb.UserComponents do
   use Gettext, backend: HarmonyWeb.Gettext
   use HarmonyWeb, :verified_routes
 
+  import HarmonyWeb.CoreComponents
+
   alias Harmony.Accounts.User
   alias HarmonyWeb.OnlineUsers
 
@@ -47,6 +49,42 @@ defmodule HarmonyWeb.UserComponents do
         <.user :for={user <- @users} user={user} online={OnlineUsers.online?(@online_users, user.id)} />
       </div>
     </div>
+    """
+  end
+
+  attr :current_user, Harmony.Accounts.User
+  slot :inner_block, required: false
+
+  def users_list_actions(assigns) do
+    ~H"""
+    <ul class="relative z-10 flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end bg-slate-300 py-2">
+      <li class="text-[0.8125rem] leading-6 text-zinc-900">
+        {@current_user.username}
+      </li>
+
+      <li>
+        <.link
+          href={~p"/users/settings"}
+          title="Settings"
+          class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
+        >
+          <.icon name="hero-user-circle" />
+          <div class="sr-only">Settings</div>
+        </.link>
+      </li>
+
+      <li>
+        <.link
+          href={~p"/users/log_out"}
+          method="delete"
+          title="Log out"
+          class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
+        >
+          <.icon name="hero-arrow-right-start-on-rectangle" />
+          <div class="sr-only">Log out</div>
+        </.link>
+      </li>
+    </ul>
     """
   end
 end

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -44,7 +44,7 @@ defmodule HarmonyWeb.ChatRoomLive do
     <div class="flex flex-col shrink-0 w-64 bg-slate-100 push-right">
       <.users_list users={@users} online_users={@online_users} />
 
-      <.rooms_list_actions current_user={@current_user} />
+      <.users_list_actions current_user={@current_user} />
     </div>
 
     <%= if @current_user.role == :admin do %>

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -4,8 +4,7 @@ defmodule HarmonyWeb.ChatRoomLive do
   alias Harmony.Accounts
   alias Harmony.Chat
   alias Harmony.Chat.Message
-  alias HarmonyWeb.Components.RoomEditComponent
-  alias HarmonyWeb.Components.RoomNewComponent
+  alias HarmonyWeb.Components.{RoomEditComponent, RoomIndexComponent, RoomNewComponent}
   alias HarmonyWeb.OnlineUsers
 
   def render(assigns) do
@@ -14,6 +13,7 @@ defmodule HarmonyWeb.ChatRoomLive do
       <.rooms_list_header is_admin={is_admin(@current_user)} />
       <.rooms_list title="Rooms">
         <.rooms_list_item :for={room <- @rooms} room={room} active={room.id == @room.id} />
+        <.rooms_list_xitem on_click={show_modal("index-room-modal")} icon="plus" title="Add a room" />
       </.rooms_list>
     </div>
 
@@ -59,6 +59,11 @@ defmodule HarmonyWeb.ChatRoomLive do
         />
       <% end %>
     <% end %>
+    <.live_component
+      module={RoomIndexComponent}
+      id="room-index-component"
+      current_user={@current_user}
+    />
     """
   end
 
@@ -122,6 +127,12 @@ defmodule HarmonyWeb.ChatRoomLive do
 
     socket
     |> assign(online_users: online_users)
+    |> noreply
+  end
+
+  def handle_info({:joined_room, %Chat.Room{}}, socket) do
+    socket
+    |> assign(:rooms, Chat.list_joined_rooms(socket.assigns.current_user))
     |> noreply
   end
 

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -59,7 +59,8 @@ defmodule HarmonyWeb.ChatRoomLive do
   end
 
   def mount(_params, _session, socket) do
-    rooms = Chat.list_rooms()
+    # rooms = Chat.list_rooms()
+    rooms = Chat.list_joined_rooms(socket.assigns.current_user)
     users = Accounts.list_users()
 
     if connected?(socket) do

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -33,7 +33,11 @@ defmodule HarmonyWeb.ChatRoomLive do
             show_delete={@current_user == message.user}
           />
         </div>
-        <.message_send_form form={@send_message_form} room={@room} />
+        <.message_send_form
+          :if={Chat.joined?(@room, @current_user)}
+          form={@send_message_form}
+          room={@room}
+        />
       <% end %>
     </div>
 
@@ -132,6 +136,10 @@ defmodule HarmonyWeb.ChatRoomLive do
       {:ok, %Chat.Message{}} ->
         socket
         |> assign_message_form(Chat.change_message(%Message{}))
+
+      {:error, :unauthorized} ->
+        socket
+        |> put_flash(:error, "You are not authorized to send messages here")
 
       {:error, changeset} ->
         socket

--- a/priv/repo/migrations/20250219234759_create_room_memberships.exs
+++ b/priv/repo/migrations/20250219234759_create_room_memberships.exs
@@ -1,0 +1,18 @@
+defmodule Harmony.Repo.Migrations.CreateRoomMemberships do
+  use Ecto.Migration
+
+  def change do
+    create table(:room_memberships, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :user_id, references(:users, on_delete: :delete_all, type: :binary_id), null: false
+      add :room_id, references(:rooms, on_delete: :delete_all, type: :binary_id), null: false
+      add :last_read_id, :uuid
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:room_memberships, [:user_id])
+    create index(:room_memberships, [:room_id])
+    create unique_index(:room_memberships, [:user_id, :room_id])
+  end
+end

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -98,6 +98,35 @@ defmodule Harmony.ChatTest do
 
       assert lr == nil
     end
+
+    test "list_joined_rooms/1 lists the rooms a user has joined" do
+      [room1, room2] = insert_pair(:room)
+      [other_room1, other_room2] = insert_pair(:room)
+      user = user_fixture()
+
+      Chat.join_room!(room1, user)
+      Chat.join_room!(room2, user)
+      joined_rooms = Chat.list_joined_rooms(user)
+
+      assert room1 in joined_rooms
+      assert room2 in joined_rooms
+      refute other_room1 in joined_rooms
+      refute other_room2 in joined_rooms
+    end
+
+    test "list_joined_rooms/1 sorts by room name" do
+      [room1, room2] = insert_pair(:room)
+      aard = insert(:room, name: "aardvark")
+      user = user_fixture()
+
+      Chat.join_room!(room1, user)
+      Chat.join_room!(room2, user)
+      Chat.join_room!(aard, user)
+      [first | _rest] = joined_rooms = Chat.list_joined_rooms(user)
+
+      assert aard in joined_rooms
+      assert first == aard
+    end
   end
 
   describe "messages" do

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -101,17 +101,6 @@ defmodule Harmony.ChatTest do
       assert lr == nil
     end
 
-    test "toggle_room_membership/2 toggles a room membership for a user" do
-      room = insert(:room)
-      user = user_fixture()
-
-      refute Chat.joined?(room, user)
-      assert Chat.toggle_room_membership(room, user) == {room, true}
-      assert Chat.joined?(room, user)
-      assert Chat.toggle_room_membership(room, user) == {room, false}
-      refute Chat.joined?(room, user)
-    end
-
     test "list_joined_rooms/1 lists the rooms a user has joined" do
       [room1, room2] = insert_pair(:room)
       [other_room1, other_room2] = insert_pair(:room)
@@ -149,6 +138,35 @@ defmodule Harmony.ChatTest do
 
       assert Chat.joined?(room, user)
       refute Chat.joined?(other_room, user)
+    end
+
+    test "list_rooms_with_joins/1 lists all of the servers rooms, along with the given users join status" do
+      user = user_fixture()
+      [room1, room2] = insert_pair(:room)
+      other_room = insert(:room)
+      aard = insert(:room, name: "aaardvark")
+      Chat.join_room!(room1, user)
+      Chat.join_room!(room2, user)
+
+      rooms_with_joined = Chat.list_rooms_with_joined(user)
+
+      assert {room1, true} in rooms_with_joined
+      assert {room2, true} in rooms_with_joined
+      assert {other_room, false} in rooms_with_joined
+
+      # It alphabetized the list
+      assert rooms_with_joined |> List.first() == {aard, false}
+    end
+
+    test "toggle_room_membership/2 toggles a room membership for a user" do
+      room = insert(:room)
+      user = user_fixture()
+
+      refute Chat.joined?(room, user)
+      assert Chat.toggle_room_membership(room, user) == {room, true}
+      assert Chat.joined?(room, user)
+      assert Chat.toggle_room_membership(room, user) == {room, false}
+      refute Chat.joined?(room, user)
     end
   end
 

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -101,6 +101,17 @@ defmodule Harmony.ChatTest do
       assert lr == nil
     end
 
+    test "toggle_room_membership/2 toggles a room membership for a user" do
+      room = insert(:room)
+      user = user_fixture()
+
+      refute Chat.joined?(room, user)
+      assert Chat.toggle_room_membership(room, user) == {room, true}
+      assert Chat.joined?(room, user)
+      assert Chat.toggle_room_membership(room, user) == {room, false}
+      refute Chat.joined?(room, user)
+    end
+
     test "list_joined_rooms/1 lists the rooms a user has joined" do
       [room1, room2] = insert_pair(:room)
       [other_room1, other_room2] = insert_pair(:room)

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -88,6 +88,16 @@ defmodule Harmony.ChatTest do
       assert {:error, :not_authorized} = Chat.delete_room_by_id(user, room.id)
       refute Chat.get_room(room.name) == nil
     end
+
+    test "join_room!/2 adds a room membership for a user" do
+      room = insert(:room)
+      user = user_fixture()
+
+      assert %Harmony.Chat.RoomMembership{room: ^room, user: ^user, last_read_id: lr} =
+               Chat.join_room!(room, user)
+
+      assert lr == nil
+    end
   end
 
   describe "messages" do

--- a/test/harmony_web/feature/user_can_edit_a_room_test.exs
+++ b/test/harmony_web/feature/user_can_edit_a_room_test.exs
@@ -3,6 +3,8 @@ defmodule HarmonyWeb.UserEditARoomTest do
   import Harmony.Factory
   import Harmony.AccountsFixtures
 
+  alias Harmony.Chat
+
   setup %{conn: conn} do
     password = valid_user_password()
     user = user_fixture(%{password: password})
@@ -12,6 +14,7 @@ defmodule HarmonyWeb.UserEditARoomTest do
   test "admins can edit a chat room", %{conn: conn, user: user} do
     user |> set_role(:admin)
     room = insert(:room)
+    Chat.join_room!(room, user)
 
     conn
     |> visit(~p"/rooms/#{room.name}")

--- a/test/harmony_web/feature/user_can_see_a_list_of_chat_rooms_test.exs
+++ b/test/harmony_web/feature/user_can_see_a_list_of_chat_rooms_test.exs
@@ -3,13 +3,17 @@ defmodule HarmonyWeb.UserCanSeeAListOfChatRoomsTest do
   import Harmony.Factory
   import Harmony.AccountsFixtures
 
+  alias Harmony.Chat
+
   setup %{conn: conn} do
     user = user_fixture()
     %{conn: log_in_user(conn, user), user: user}
   end
 
-  test "user can see a list of chat rooms", %{conn: conn} do
+  test "user can see a list of chat rooms", %{conn: conn, user: user} do
     [room1, room2] = insert_pair(:room)
+    Chat.join_room!(room1, user)
+    Chat.join_room!(room2, user)
 
     conn
     |> visit("/")
@@ -17,8 +21,9 @@ defmodule HarmonyWeb.UserCanSeeAListOfChatRoomsTest do
     |> assert_has("#rooms-list .name", text: room2.name)
   end
 
-  test "user can toggle the room topic visibility", %{conn: conn} do
+  test "user can toggle the room topic visibility", %{conn: conn, user: user} do
     room = insert(:room)
+    Chat.join_room!(room, user)
 
     conn
     |> visit("/")
@@ -30,8 +35,10 @@ defmodule HarmonyWeb.UserCanSeeAListOfChatRoomsTest do
     |> assert_has("#room-header .topic", text: room.topic)
   end
 
-  test "user can switch between rooms", %{conn: conn} do
+  test "user can switch between rooms", %{conn: conn, user: user} do
     [room1, room2] = insert_pair(:room)
+    Chat.join_room!(room1, user)
+    Chat.join_room!(room2, user)
 
     conn
     |> visit("/")

--- a/test/harmony_web/feature/user_can_see_each_others_online_status_test.exs
+++ b/test/harmony_web/feature/user_can_see_each_others_online_status_test.exs
@@ -8,7 +8,6 @@ defmodule HarmonyWeb.UsersCanSeeEachOthersOnlineStatusTest do
     %{conn: conn, room: room}
   end
 
-  @tag focus: true
   test "users can see each other's online status", %{conn: conn, room: room} do
     user1 = user_fixture()
     user2 = user_fixture()

--- a/test/harmony_web/feature/user_can_see_messages_test.exs
+++ b/test/harmony_web/feature/user_can_see_messages_test.exs
@@ -3,9 +3,12 @@ defmodule HarmonyWeb.UsersCanSeeMessages do
   import Harmony.Factory
   import Harmony.AccountsFixtures
 
+  alias Harmony.Chat
+
   setup %{conn: conn} do
     user = user_fixture()
     room = insert(:room)
+    Chat.join_room!(room, user)
     %{conn: log_in_user(conn, user), user: user, room: room}
   end
 
@@ -19,9 +22,10 @@ defmodule HarmonyWeb.UsersCanSeeMessages do
     |> assert_has("#messages-list .message-user", text: m1.user.username)
   end
 
-  test "each room has it's own messages", %{conn: conn, room: room} do
+  test "each room has it's own messages", %{conn: conn, room: room, user: user} do
     [m1, m2] = insert_pair(:message, room: room, body: "Show these messages")
     other_room = insert(:room)
+    Chat.join_room!(other_room, user)
     [om1, om2] = insert_pair(:message, room: other_room, body: "Not these messages")
 
     conn

--- a/test/harmony_web/feature/user_can_see_messages_test.exs
+++ b/test/harmony_web/feature/user_can_see_messages_test.exs
@@ -36,13 +36,13 @@ defmodule HarmonyWeb.UsersCanSeeMessages do
     |> refute_has("#messages-#{om1.id}")
     |> refute_has("#messages-#{om2.id}")
     # The other room has only *it's* own messages
-    |> click_link(other_room.name)
+    |> click_link(".rooms-list-item", other_room.name)
     |> assert_has("#messages-#{om1.id}")
     |> assert_has("#messages-#{om2.id}")
     |> refute_has("#messages-#{m1.id}")
     |> refute_has("#messages-#{m2.id}")
     # Now back to the first
-    |> click_link(room.name)
+    |> click_link(".rooms-list-item", room.name)
     |> assert_has("#messages-#{m1.id}")
     |> assert_has("#messages-#{m2.id}")
     |> refute_has("#messages-#{om1.id}")

--- a/test/harmony_web/feature/user_can_send_messages_test.exs
+++ b/test/harmony_web/feature/user_can_send_messages_test.exs
@@ -3,18 +3,28 @@ defmodule HarmonyWeb.UsersCanSendMessages do
   import Harmony.Factory
   import Harmony.AccountsFixtures
 
+  alias Harmony.Chat
+
   setup %{conn: conn} do
     user = user_fixture()
     room = insert(:room)
     %{conn: log_in_user(conn, user), user: user, room: room}
   end
 
-  test "users can send messages", %{conn: conn, user: user, room: room} do
+  test "joined users can send messages", %{conn: conn, user: user, room: room} do
+    Chat.join_room!(room, user)
+
     conn
     |> visit("/rooms/#{room.name}")
     |> fill_in("#message-send-form textarea", "Message Body", with: "Test message body")
     |> submit()
     |> assert_has("#messages-list .message-body", text: "Test message body")
     |> assert_has("#messages-list .message-user", text: user.username)
+  end
+
+  test "unjoined users cannot send messages", %{conn: conn, room: room} do
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> refute_has("#messages-send-form")
   end
 end

--- a/test/harmony_web/feature/users_can_join_rooms_as_members_test.exs
+++ b/test/harmony_web/feature/users_can_join_rooms_as_members_test.exs
@@ -13,12 +13,28 @@ defmodule HarmonyWeb.UsersCanJoinRoomsAsMembersTest do
     |> refute_has("#rooms-list a", text: room2.name)
     |> refute_has("#rooms-list a", text: room3.name)
     |> assert_has("a", text: "Add a room")
-    |> assert_has("#room-index a", text: room1.name)
-    |> assert_has("#room-index a", text: room2.name)
-    |> assert_has("#room-index a", text: room3.name)
-    |> click_link("#room-index a", room1.name)
+    |> assert_has("#room-index .room-index-item", text: room1.name)
+    |> assert_has("#room-index .room-index-item", text: room2.name)
+    |> assert_has("#room-index .room-index-item", text: room3.name)
+    |> click_button("#room-index #room-index-item-#{room1.id} button", "Join")
     |> assert_has("#rooms-list a", text: room1.name)
     |> refute_has("#rooms-list a", text: room2.name)
     |> refute_has("#rooms-list a", text: room3.name)
+  end
+
+  test "the rooms index also shows the joined status", %{conn: conn, user: user} do
+    [room1, room2, room3] = insert_list(3, :room)
+    Harmony.Chat.join_room!(room1, user)
+
+    conn
+    |> visit("/rooms/#{room1.name}")
+    |> assert_has("#room-index #room-index-item-#{room1.id}", text: "Joined")
+    |> refute_has("#room-index #room-index-item-#{room2.id}", text: "Joined")
+    |> refute_has("#room-index #room-index-item-#{room3.id}", text: "Joined")
+    |> click_button("#room-index #room-index-item-#{room2.id} button", "Join")
+    |> assert_has("#room-index #room-index-item-#{room2.id}", text: "Joined")
+    |> assert_has("#room-index #room-index-item-#{room2.id} button", text: "Leave")
+    |> click_button("#room-index #room-index-item-#{room1.id} button", "Leave")
+    |> refute_has("#room-index #room-index-item-#{room1.id}", text: "Joined")
   end
 end

--- a/test/harmony_web/feature/users_can_join_rooms_as_members_test.exs
+++ b/test/harmony_web/feature/users_can_join_rooms_as_members_test.exs
@@ -1,0 +1,24 @@
+defmodule HarmonyWeb.UsersCanJoinRoomsAsMembersTest do
+  use HarmonyWeb.FeatureCase
+  import Harmony.Factory
+
+  setup :register_and_log_in_user
+
+  test "users can see a list of available rooms and join them", %{conn: conn} do
+    [room1, room2, room3] = insert_list(3, :room)
+
+    conn
+    |> visit("/")
+    |> refute_has("#rooms-list a", text: room1.name)
+    |> refute_has("#rooms-list a", text: room2.name)
+    |> refute_has("#rooms-list a", text: room3.name)
+    |> assert_has("a", text: "Add a room")
+    |> assert_has("#room-index a", text: room1.name)
+    |> assert_has("#room-index a", text: room2.name)
+    |> assert_has("#room-index a", text: room3.name)
+    |> click_link("#room-index a", room1.name)
+    |> assert_has("#rooms-list a", text: room1.name)
+    |> refute_has("#rooms-list a", text: room2.name)
+    |> refute_has("#rooms-list a", text: room3.name)
+  end
+end


### PR DESCRIPTION
As a user, I can see a list of all the rooms on a server, and then join or leave
the rooms.

Only rooms I am a member of appear on my sidebar.

I can use the rooms index to visit other rooms, but I cannot post messages in
them.

---

We are using the memberships to store some metadata about each user's membership
in a room (specifically, the last read post id). This will come in handy later
when we implement an "last-read" marker and new message notifications.
