### PR TITLE
feature/users have last read message markers

### DIFF
--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -115,8 +115,8 @@ defmodule Harmony.Chat do
       where: membership.user_id == ^user.id,
       left_join: message in assoc(room, :messages),
       on: message.id > membership.last_read_id,
-      group_by: room.id,
-      select: {room, count(message.id)},
+      group_by: [room.id, membership.id],
+      select: {room, count(message.id), is_nil(membership.last_read_id)},
       order_by: [asc: room.name]
     )
     |> Repo.all()

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -175,6 +175,7 @@ defmodule Harmony.Chat do
       {:ok, message}
     else
       false -> {:error, :unauthorized}
+      {:error, changset} -> {:error, changset}
     end
   end
 

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -109,6 +109,19 @@ defmodule Harmony.Chat do
     |> Enum.sort_by(& &1.name)
   end
 
+  def list_joined_rooms_with_unread_counts(%User{} = user) do
+    from(room in Room,
+      join: membership in assoc(room, :memberships),
+      where: membership.user_id == ^user.id,
+      left_join: message in assoc(room, :messages),
+      on: message.id > membership.last_read_id,
+      group_by: room.id,
+      select: {room, count(message.id)},
+      order_by: [asc: room.name]
+    )
+    |> Repo.all()
+  end
+
   def joined?(%Room{} = room, %User{} = user) do
     Repo.exists?(
       from r_m in RoomMembership, where: r_m.room_id == ^room.id and r_m.user_id == ^user.id

--- a/lib/harmony/chat/room.ex
+++ b/lib/harmony/chat/room.ex
@@ -12,6 +12,8 @@ defmodule Harmony.Chat.Room do
     field :topic, :string
 
     has_many :messages, Message
+    has_many :memberships, RoomMembership
+
     many_to_many :members, User, join_through: RoomMembership
 
     timestamps(type: :utc_datetime)

--- a/lib/harmony_web/components/live/room_index_component.ex
+++ b/lib/harmony_web/components/live/room_index_component.ex
@@ -63,7 +63,7 @@ defmodule HarmonyWeb.Components.RoomIndexComponent do
   def handle_event("toggle-room", %{"room" => room_name}, socket) do
     room = Chat.get_room(room_name)
     {room, joined?} = Chat.toggle_room_membership(room, socket.assigns.current_user)
-    send(self(), {:joined_room, room})
+    send(self(), {:toggled_room, room})
 
     socket
     |> stream_insert(:rooms, {room, joined?})

--- a/lib/harmony_web/components/message_components.ex
+++ b/lib/harmony_web/components/message_components.ex
@@ -11,9 +11,19 @@ defmodule HarmonyWeb.MessageComponents do
   alias Harmony.Chat.Message
   # alias Phoenix.LiveView.JS
 
-  attr :message, Message, required: true
+  # attr :message, Message OR :unread_marker
+  attr :message, :any, required: true
   attr :show_delete, :boolean, default: false
   attr :dom_id, :string
+
+  def message_item(%{message: :unread_marker} = assigns) do
+    ~H"""
+    <div id={@dom_id} class="w-full flex text-red-500 items-center gap-3 pr-5">
+      <div class="w-full h-px grow bg-red-500"></div>
+      <div class="text-sm">New</div>
+    </div>
+    """
+  end
 
   def message_item(assigns) do
     ~H"""

--- a/lib/harmony_web/components/room_components.ex
+++ b/lib/harmony_web/components/room_components.ex
@@ -13,6 +13,7 @@ defmodule HarmonyWeb.RoomComponents do
 
   attr :active, :boolean, required: true
   attr :room, Room, required: true
+  attr :unread, :integer, default: 0
 
   def rooms_list_item(assigns) do
     ~H"""
@@ -24,8 +25,14 @@ defmodule HarmonyWeb.RoomComponents do
       patch={~p"/rooms/#{@room.name}"}
     >
       <.icon name="hero-hashtag" class="h-4 w-4" />
-      <span class={["ml-2 leading-none name", @active && "font-bold"]}>
+      <span class={["ml-2 leading-none name grow", @active && "font-bold"]}>
         {@room.name}
+      </span>
+      <span
+        :if={@unread > 0}
+        class="flex justify-center items-center rounded-full bg-sky-500 text-white h-5 w-5 text-xs font-bold"
+      >
+        {@unread}
       </span>
     </.link>
     """

--- a/lib/harmony_web/components/room_components.ex
+++ b/lib/harmony_web/components/room_components.ex
@@ -30,7 +30,7 @@ defmodule HarmonyWeb.RoomComponents do
       </span>
       <span
         :if={@unread > 0}
-        class="flex justify-center items-center rounded-full bg-sky-500 text-white h-5 w-5 text-xs font-bold"
+        class="unread-count flex justify-center items-center rounded-full bg-sky-500 text-white h-5 w-5 text-xs font-bold"
       >
         {@unread}
       </span>

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -141,6 +141,31 @@ defmodule Harmony.ChatTest do
       assert first == aard
     end
 
+    test "list_joined_rooms_with_unread/1" do
+      user = user_fixture()
+
+      room1 =
+        insert(:room)
+        |> with_messages(count: 2)
+        |> read_messages(user)
+
+      [room2, room3] =
+        insert_pair(:room)
+        |> with_messages(count: 2)
+        |> read_messages(user)
+        |> with_messages(count: 2)
+
+      room4 = insert(:room) |> with_messages(count: 3)
+      Chat.join_room!(room4, user)
+
+      list = Chat.list_joined_rooms_with_unread_counts(user)
+
+      assert {room1, 0} in list
+      assert {room2, 2} in list
+      assert {room3, 2} in list
+      assert {room4, 0} in list
+    end
+
     test "joined?/2 returns if a user is a member of a room" do
       user = user_fixture()
       room = insert(:room)

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -160,10 +160,10 @@ defmodule Harmony.ChatTest do
 
       list = Chat.list_joined_rooms_with_unread_counts(user)
 
-      assert {room1, 0} in list
-      assert {room2, 2} in list
-      assert {room3, 2} in list
-      assert {room4, 0} in list
+      assert {room1, 0, false} in list
+      assert {room2, 2, false} in list
+      assert {room3, 2, false} in list
+      assert {room4, 0, true} in list
     end
 
     test "joined?/2 returns if a user is a member of a room" do

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -88,6 +88,17 @@ defmodule Harmony.ChatTest do
       assert {:error, :not_authorized} = Chat.delete_room_by_id(user, room.id)
       refute Chat.get_room(room.name) == nil
     end
+
+    test "update_last_read_id/2 updates the last read message id for a user in a room" do
+      user = user_fixture()
+      room = insert(:room)
+      message = insert(:message, room: room)
+      Chat.join_room!(room, user)
+
+      id = message.id
+      assert Chat.get_last_read_id(room, user) == nil
+      assert {:ok, %Chat.RoomMembership{last_read_id: ^id}} = Chat.update_last_read_id(room, user)
+    end
   end
 
   describe "room_memberships" do

--- a/test/harmony_web/feature/user_can_delete_messages_test.exs
+++ b/test/harmony_web/feature/user_can_delete_messages_test.exs
@@ -11,7 +11,6 @@ defmodule HarmonyWeb.UsersCanDeleteMessages do
 
   test "users can delete their own messages", %{conn: conn, room: room, user: user} do
     [m1, m2] = insert_pair(:message, room: room, user: user)
-    Harmony.Chat.join_room!(room, user)
 
     conn
     |> visit("/rooms/#{room.name}")

--- a/test/harmony_web/feature/user_can_delete_messages_test.exs
+++ b/test/harmony_web/feature/user_can_delete_messages_test.exs
@@ -11,6 +11,7 @@ defmodule HarmonyWeb.UsersCanDeleteMessages do
 
   test "users can delete their own messages", %{conn: conn, room: room, user: user} do
     [m1, m2] = insert_pair(:message, room: room, user: user)
+    Harmony.Chat.join_room!(room, user)
 
     conn
     |> visit("/rooms/#{room.name}")

--- a/test/harmony_web/feature/users-have-unread-markers_test.exs
+++ b/test/harmony_web/feature/users-have-unread-markers_test.exs
@@ -1,0 +1,75 @@
+defmodule HarmonyWeb.UsersHaveUnreadMarkersTest do
+  use HarmonyWeb.FeatureCase
+  import Harmony.Factory
+
+  setup :register_and_log_in_user
+
+  test "users see an unread messages marker for new messages", %{conn: conn, user: user} do
+    room = insert(:room)
+    Harmony.Chat.join_room!(room, user)
+
+    [m1, m2] = insert_pair(:message, room: room)
+    Harmony.Chat.update_last_read_id(room, user)
+    [m3, m4] = insert_pair(:message, room: room)
+
+    conn
+    |> visit("/rooms/#{room.name}")
+    # The first two messages, followed by the uneread messages marker
+    |> assert_has("#messages-#{m1.id}+#messages-#{m2.id}+#messages-unread-marker", text: "New")
+    # The unread messages marker, followed by the final two messages
+    |> assert_has("#messages-unread-marker+#messages-#{m3.id}+#messages-#{m4.id}", text: m4.body)
+
+    # after viewing the page, the last read id is updated
+    assert Harmony.Chat.get_last_read_id(room, user) == m4.id
+  end
+
+  test "there is no marker if the room has just been joined", %{conn: conn, user: user} do
+    room = insert(:room)
+    Harmony.Chat.join_room!(room, user)
+
+    insert_list(3, :message, room: room)
+
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> refute_has("#messages-unread-marker", text: "New")
+  end
+
+  test "there is no marker if all messages have been read", %{conn: conn, user: user} do
+    room = insert(:room)
+    Harmony.Chat.join_room!(room, user)
+
+    insert_list(3, :message, room: room)
+    Harmony.Chat.update_last_read_id(room, user)
+
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> refute_has("#messages-unread-marker", text: "New")
+  end
+
+  test "there is no marker for visitors", %{conn: conn} do
+    room = insert(:room)
+
+    insert_list(3, :message, room: room)
+
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> refute_has("#messages-unread-marker", text: "New")
+  end
+
+  test "the unread messages marker updates on new messages", %{conn: conn, user: user} do
+    room = insert(:room)
+    Harmony.Chat.join_room!(room, user)
+
+    insert_list(3, :message, room: room)
+    Harmony.Chat.update_last_read_id(room, user)
+
+    conn = visit(conn, "/rooms/#{room.name}")
+    # The actual exercise - sending a new message
+    m4 = insert(:message, room: room)
+    send(conn.view.pid, {:new_message, m4})
+    # Need to use the conn again to get it to process the message
+    assert_has(conn, ".message-body", text: m4.body)
+
+    assert Harmony.Chat.get_last_read_id(room, user) == m4.id
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -2,11 +2,44 @@ defmodule Harmony.Factory do
   # with Ecto
   use ExMachina.Ecto, repo: Harmony.Repo
 
+  alias Harmony.Accounts.User
+  alias Harmony.Chat.Room
+
   def room_factory do
     %Harmony.Chat.Room{
       name: sequence(:name, &"room-#{&1}"),
       topic: sequence(:name, &"room-#{&1} is the best room around")
     }
+  end
+
+  def with_messages(%Room{} = room, count: count) do
+    insert_list(count, :message, room: room)
+    room
+  end
+
+  def with_messages([%Room{} = room | rest], count: count) do
+    insert_list(count, :message, room: room)
+    [room | with_messages(rest, count: count)]
+  end
+
+  def with_messages([], count: _count) do
+    []
+  end
+
+  def read_messages(%Room{} = room, %User{} = user) do
+    Harmony.Chat.join_room!(room, user)
+    Harmony.Chat.update_last_read_id(room, user)
+    room
+  end
+
+  def read_messages([%Room{} = room | rest], %User{} = user) do
+    Harmony.Chat.join_room!(room, user)
+    Harmony.Chat.update_last_read_id(room, user)
+    [room | read_messages(rest, user)]
+  end
+
+  def read_messages([], %User{}) do
+    []
   end
 
   def message_factory do


### PR DESCRIPTION
As a user

* I should see a count of unread messages in my sidebar for each room I
  am a member of. This count should increase in (near) real-time as new messages
  are received.

* The count should not show for rooms I have just recently joined but haven't
  opened yet, even if new messages are sent to that room.

* I should see an unread messages marker in the message list separating old from
  new messages. This marker should only show if there are new messages, and
  should not show for a room I am reading for the first time
