### PR TITLE
Add simple date dividers to char rooms

### DIFF
--- a/lib/harmony_web/components/message_components.ex
+++ b/lib/harmony_web/components/message_components.ex
@@ -16,6 +16,19 @@ defmodule HarmonyWeb.MessageComponents do
   attr :show_delete, :boolean, default: false
   attr :dom_id, :string
 
+  def message_item(%{message: {:date_divider, date}} = assigns) do
+    assigns = assign(assigns, :date, date)
+
+    ~H"""
+    <div :if={@date != Date.utc_today()} id={@dom_id} class="flex flex-col items-center mt-2">
+      <hr class="w-full" />
+      <span class="flex items-center justify-center -mt-3 bg-white h-6 px-3 rounded-full border text-xs font-semibold mx-auto">
+        {format_date(@date)}
+      </span>
+    </div>
+    """
+  end
+
   def message_item(%{message: :unread_marker} = assigns) do
     ~H"""
     <div id={@dom_id} class="w-full flex text-red-500 items-center gap-3 pr-5">
@@ -68,6 +81,16 @@ defmodule HarmonyWeb.MessageComponents do
       </div>
     </div>
     """
+  end
+
+  defp format_date(%Date{} = date) do
+    today = Date.utc_today()
+
+    case Date.diff(today, date) do
+      0 -> "Today"
+      1 -> "Yesterday"
+      _ -> date |> Calendar.strftime("%A, %d %B %Y")
+    end
   end
 
   attr :message, Message, required: true

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -91,6 +91,7 @@ defmodule HarmonyWeb.ChatRoomLive do
     |> stream_configure(:messages,
       dom_id: fn
         %Chat.Message{id: id} -> "messages-#{id}"
+        {:date_divider, date} -> "messages-date-divier-#{date}"
         :unread_marker -> "messages-unread-marker"
       end
     )
@@ -108,6 +109,7 @@ defmodule HarmonyWeb.ChatRoomLive do
     messages =
       room
       |> Chat.list_messages()
+      |> insert_date_dividers()
       |> maybe_insert_unread_marker(last_read_id)
 
     Chat.update_last_read_id(room, socket.assigns.current_user)
@@ -249,10 +251,23 @@ defmodule HarmonyWeb.ChatRoomLive do
     role == :admin
   end
 
+  defp insert_date_dividers(messages) do
+    messages
+    |> Enum.group_by(fn message ->
+      message.inserted_at
+      |> DateTime.to_date()
+    end)
+    |> Enum.sort_by(fn {date, _msg} -> date end, &(Date.compare(&1, &2) != :gt))
+    |> Enum.flat_map(fn {date, messages} -> messages ++ [{:date_divider, date}] end)
+  end
+
   defp maybe_insert_unread_marker(messages, nil), do: messages
 
   defp maybe_insert_unread_marker(messages, id) do
-    case Enum.split_while(messages, &(&1.id <= id)) do
+    case Enum.split_while(messages, fn
+           %Message{} = message -> message.id <= id
+           _ -> true
+         end) do
       {read, []} -> read
       # {read, unread} -> read ++ [:unread_marker | unread]
       {read, unread} -> read ++ [:unread_marker | unread]

--- a/test/harmony_web/feature/chat_rooms_have_date_dividers_test.exs
+++ b/test/harmony_web/feature/chat_rooms_have_date_dividers_test.exs
@@ -1,0 +1,23 @@
+defmodule HarmonyWeb.ChatRoomsHaveDateDividersTest do
+  use HarmonyWeb.FeatureCase, async: true
+  import Harmony.Factory
+
+  setup :register_and_log_in_user
+
+  test "chat rooms have date diviers", %{conn: conn} do
+    room = insert(:room)
+    yesterday = yesterday()
+    insert(:message, room: room, inserted_at: yesterday)
+    insert(:message, room: room)
+
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> open_browser
+    |> assert_has("#messages-date-divier-#{DateTime.to_date(yesterday)}", text: "Yesterday")
+  end
+
+  defp yesterday do
+    DateTime.utc_now()
+    |> DateTime.add(-1, :day)
+  end
+end


### PR DESCRIPTION
Added some simple date dividers to the chat rooms.

These dividers should separate messages by date, and are intended to be read
from the bottom-up: i.e. the posts *above* the divider are from the specified
date.

Since we aren't reading any timezone data, for the moment the dates are being
read from server time. In the future, accounting for the user's timezone (e.g.
by reading it from the browser upon loading the WebSocket) might be preferable.
