### PR TITLE
feature/messages can have threaded replies

### DIFF
--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -246,6 +246,19 @@ defmodule Harmony.Chat do
 
   # Chat.Message
 
+  def get_message(id) do
+    Message
+    |> preload(:user)
+    |> Repo.get(id)
+  end
+
+  def get_message_with_replies(id) do
+    Message
+    |> preload(:user)
+    |> preload(:replies)
+    |> Repo.get(id)
+  end
+
   @spec list_messages(Room.t()) :: list(Message.t())
   def list_messages(%Room{id: room_id}) do
     Message

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -248,14 +248,18 @@ defmodule Harmony.Chat do
 
   def get_message(id) do
     Message
-    |> preload(:user)
+    # Preload the profiles because otherwise we get an n+1 problem loading all
+    # the display names and avatars
+    |> preload(user: :profile)
     |> Repo.get(id)
   end
 
   def get_message_with_replies(id) do
     Message
-    |> preload(:user)
-    |> preload(:replies)
+    # Preload the profiles because otherwise we get an n+1 problem loading all
+    # the display names and avatars
+    |> preload(user: :profile)
+    |> preload(replies: [user: :profile])
     |> Repo.get(id)
   end
 
@@ -264,7 +268,9 @@ defmodule Harmony.Chat do
     Message
     |> where([m], m.room_id == ^room_id)
     |> order_by([m], asc: :inserted_at, asc: :id)
-    |> preload(:user)
+    # Preload the profiles because otherwise we get an n+1 problem loading all
+    # the display names and avatars
+    |> preload(user: :profile)
     |> Repo.all()
   end
 
@@ -281,6 +287,8 @@ defmodule Harmony.Chat do
            %Message{user: user, room: room}
            |> Message.changeset(attrs)
            |> Repo.insert() do
+      # the event handlers expect the profile preloaded
+      message = Repo.preload(message, user: :profile)
       Phoenix.PubSub.broadcast!(@pubsub, topic(room.id), {:new_message, message})
       {:ok, message}
     else

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -1,7 +1,7 @@
 defmodule Harmony.Chat do
   alias Harmony.Repo
   alias Harmony.Accounts.User
-  alias Harmony.Chat.{Message, Room, RoomMembership}
+  alias Harmony.Chat.{Message, Reply, Room, RoomMembership}
 
   import Ecto.Changeset
   import Ecto.Query
@@ -303,6 +303,55 @@ defmodule Harmony.Chat do
       %Message{user_id: ^user_id} = message ->
         Phoenix.PubSub.broadcast!(@pubsub, topic(message.room_id), {:delete_message, message})
         Repo.delete(message)
+
+      _ ->
+        {:error, "Message does not exist or is not owned by user"}
+    end
+  end
+
+  # Chat.Reply
+
+  @spec list_replies(UUIDv7.t()) :: list(Reply.t())
+  def list_replies(message_id) do
+    Reply
+    |> where([r], r.message_id == ^message_id)
+    |> Repo.all()
+  end
+
+  @spec change_reply(Reply.t(), map()) :: Ecto.Changeset.t(Reply.t())
+  def change_reply(%Reply{} = reply, attrs \\ %{}) do
+    Reply.changeset(reply, attrs)
+  end
+
+  @spec create_reply(User.t(), Message.t(), map()) ::
+          {:ok, Reply.t()} | {:error, Ecto.Changeset.t(Reply.t())} | {:error, :unauthorized}
+  def create_reply(%User{} = user, %Message{} = message, attrs) do
+    with {:ok, reply} <-
+           %Reply{user: user, message: message}
+           |> Reply.changeset(attrs)
+           |> Repo.insert() do
+      # the event handlers expect the profile preloaded
+      reply = Repo.preload(reply, user: :profile)
+      Phoenix.PubSub.broadcast!(@pubsub, topic(message.room_id), {:new_reply, message.id, reply})
+      {:ok, reply}
+    else
+      {:error, changset} -> {:error, changset}
+    end
+  end
+
+  @spec delete_reply_by_id(UUIDv7.t(), User.t()) :: {:ok, Reply.t()} | {:error, String.t()}
+  def delete_reply_by_id(id, %User{id: user_id}) do
+    case Repo.get(Reply, id) do
+      %Reply{user_id: ^user_id} = reply ->
+        %Message{room_id: room_id} = get_message(reply.message_id)
+
+        Phoenix.PubSub.broadcast!(
+          @pubsub,
+          topic(room_id),
+          {:delete_reply, reply.message_id, reply}
+        )
+
+        Repo.delete(reply)
 
       _ ->
         {:error, "Message does not exist or is not owned by user"}

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -255,12 +255,13 @@ defmodule Harmony.Chat do
   end
 
   def get_message_with_replies(id) do
+    replies = from reply in Reply, order_by: [asc: :inserted_at, asc: :id]
+
     Message
-    # Preload the profiles because otherwise we get an n+1 problem loading all
-    # the display names and avatars
+    |> where([m], m.id == ^id)
     |> preload(user: :profile)
-    |> preload(replies: [user: :profile])
-    |> Repo.get(id)
+    |> preload(replies: ^{replies, [user: :profile]})
+    |> Repo.one!()
   end
 
   @spec list_messages(Room.t()) :: list(Message.t())
@@ -311,13 +312,6 @@ defmodule Harmony.Chat do
   end
 
   # Chat.Reply
-
-  @spec list_replies(UUIDv7.t()) :: list(Reply.t())
-  def list_replies(message_id) do
-    Reply
-    |> where([r], r.message_id == ^message_id)
-    |> Repo.all()
-  end
 
   @spec change_reply(Reply.t(), map()) :: Ecto.Changeset.t(Reply.t())
   def change_reply(%Reply{} = reply, attrs \\ %{}) do

--- a/lib/harmony/chat.ex
+++ b/lib/harmony/chat.ex
@@ -271,6 +271,7 @@ defmodule Harmony.Chat do
     # Preload the profiles because otherwise we get an n+1 problem loading all
     # the display names and avatars
     |> preload(user: :profile)
+    |> preload(replies: [user: :profile])
     |> Repo.all()
   end
 
@@ -287,8 +288,8 @@ defmodule Harmony.Chat do
            %Message{user: user, room: room}
            |> Message.changeset(attrs)
            |> Repo.insert() do
-      # the event handlers expect the profile preloaded
-      message = Repo.preload(message, user: :profile)
+      # the event handlers expect the profile and replies preloaded
+      message = Repo.preload(message, user: :profile, replies: [user: :profile])
       Phoenix.PubSub.broadcast!(@pubsub, topic(room.id), {:new_message, message})
       {:ok, message}
     else

--- a/lib/harmony/chat/message.ex
+++ b/lib/harmony/chat/message.ex
@@ -1,7 +1,7 @@
 defmodule Harmony.Chat.Message do
   use Ecto.Schema
   import Ecto.Changeset
-  alias Harmony.Chat.Room
+  alias Harmony.Chat.{Reply, Room}
   alias Harmony.Accounts.User
 
   @type t() :: %__MODULE__{
@@ -21,6 +21,8 @@ defmodule Harmony.Chat.Message do
     field :body, :string
     belongs_to :user, User
     belongs_to :room, Room
+
+    has_many :replies, Reply
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/harmony/chat/reply.ex
+++ b/lib/harmony/chat/reply.ex
@@ -1,0 +1,25 @@
+defmodule Harmony.Chat.Reply do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Harmony.Accounts.User
+  alias Harmony.Chat.Message
+
+  @primary_key {:id, UUIDv7, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "replies" do
+    field :body, :string
+
+    belongs_to :message, Message
+    belongs_to :user, User
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(reply, attrs) do
+    reply
+    |> cast(attrs, [:body])
+    |> validate_required([:body])
+  end
+end

--- a/lib/harmony/chat/reply.ex
+++ b/lib/harmony/chat/reply.ex
@@ -5,6 +5,17 @@ defmodule Harmony.Chat.Reply do
   alias Harmony.Accounts.User
   alias Harmony.Chat.Message
 
+  @type t() :: %__MODULE__{
+          id: UUIDv7.t(),
+          body: String.t(),
+          user: User.t(),
+          user_id: Ecto.UUID.t(),
+          message: Message.t(),
+          message: UUIDv7.t(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
   @primary_key {:id, UUIDv7, autogenerate: true}
   @foreign_key_type :binary_id
   schema "replies" do

--- a/lib/harmony_web/components/live/replies_component.ex
+++ b/lib/harmony_web/components/live/replies_component.ex
@@ -49,26 +49,6 @@ defmodule HarmonyWeb.Components.RepliesComponent do
     """
   end
 
-  def update(%{new_reply: new_reply, message_id: message_id}, socket) do
-    if socket.assigns.message && message_id == socket.assigns.message.id do
-      socket
-      |> stream_insert(:replies, new_reply)
-    else
-      socket
-    end
-    |> ok
-  end
-
-  def update(%{deleted_reply: deleted_reply, message_id: message_id}, socket) do
-    if socket.assigns.message && message_id == socket.assigns.message.id do
-      socket
-      |> stream_delete(:replies, deleted_reply)
-    else
-      socket
-    end
-    |> ok
-  end
-
   def update(%{message: %Message{} = message} = assigns, socket) do
     replies = message.replies
 

--- a/lib/harmony_web/components/live/replies_component.ex
+++ b/lib/harmony_web/components/live/replies_component.ex
@@ -1,0 +1,35 @@
+defmodule HarmonyWeb.Components.RepliesComponent do
+  use HarmonyWeb, :live_component
+
+  def render(assigns) do
+    ~H"""
+    <div class="relative">
+      <div class="drawer drawer-end">
+        <input
+          id="replies-drawer"
+          type="checkbox"
+          class="drawer-toggle"
+          checked={assigns[:message] != nil}
+        />
+        <div class="drawer-side z-50">
+          <div
+            aria-label="close sidebar"
+            class="drawer-overlay backdrop-blur-[1px]"
+            phx-click="hide-replies"
+          >
+          </div>
+          <div class="menu bg-white w-5/6 md:w-1/3 h-full">
+            <div :if={@room} class="header border-b pb-3">
+              <h2 class="font-bold">Replies</h2>
+              <div>#{@room.name}</div>
+            </div>
+            <%= if assigns[:message] do %>
+              <.message_item message={@message} dom_id="reply-base-message" threaded />
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/harmony_web/components/live/replies_component.ex
+++ b/lib/harmony_web/components/live/replies_component.ex
@@ -32,63 +32,15 @@ defmodule HarmonyWeb.Components.RepliesComponent do
               <.message_item message={@message} dom_id="reply-base-message" threaded />
               <hr />
               <div id="replies-list" phx-update="stream">
-                <div
+                <.reply_item
                   :for={{dom_id, reply} <- @streams.replies}
-                  id={dom_id}
-                  class="group relative flex px-4 py-3 hover:bg-slate-100"
-                >
-                  <div class="join absolute top-4 right-4 hidden group-hover:inline-flex">
-                    <.reply_delete_button
-                      :if={@user.id == reply.user_id}
-                      reply={reply}
-                      target={@myself}
-                    />
-                  </div>
-                  <img
-                    class="h-10 w-10 rounded shrink-0 bg-slate-300"
-                    style={"background-color: #{avatar_bgcolor(reply.user.username)};"}
-                    src={avatar_path(reply.user.profile)}
-                  />
-                  <div class="ml-2">
-                    <div class="-mt-1">
-                      <.link class="text-sm font-semibold hover:underline">
-                        <span class="reply-user">{reply.user.username}</span>
-                      </.link>
-                      <span
-                        id={reply.id <> "timestamp"}
-                        phx-hook="Timestamp"
-                        data-timestamp={reply.inserted_at}
-                        class="ml-1 text-xs text-gray-500"
-                      >
-                        {message_timestamp(reply)}
-                      </span>
-                      <p class="text-sm reply-body">{reply.body}</p>
-                    </div>
-                  </div>
-                </div>
+                  dom_id={dom_id}
+                  reply={reply}
+                  show_delete={@user.id == reply.user_id}
+                  delete_target={@myself}
+                />
               </div>
-              <.form
-                for={@form}
-                id="reply-send-form"
-                phx-submit="send-reply"
-                phx-change="validate-reply"
-                phx-target={@myself}
-                class="p-2 join"
-              >
-                <label for="chat-reply-textarea" class="sr-only">Reply Body</label>
-                <textarea
-                  class="textarea textarea-primary textarea-md join-item grow"
-                  id="chat-reply-textarea"
-                  name={@form[:body].name}
-                  placeholder={"Reply in ##{@room.name}"}
-                  phx-hook="CtrlEnterSubmit"
-                  phx-debounce
-                  rows="3"
-                >{Phoenix.HTML.Form.normalize_value("textarea", @form[:body].value)}</textarea>
-                <button class="btn btn-primary join-item h-full">
-                  <.icon name="hero-paper-airplane" class="h-4 w-4" />
-                </button>
-              </.form>
+              <.send_reply_form form={@form} target={@myself} room={@room} />
             <% end %>
           </div>
         </div>
@@ -168,21 +120,5 @@ defmodule HarmonyWeb.Components.RepliesComponent do
 
   defp assign_reply_form(socket, %Ecto.Changeset{} = changeset) do
     assign(socket, :form, to_form(changeset))
-  end
-
-  defp message_timestamp(message) do
-    message.inserted_at |> Calendar.strftime("%I:%M %p on %Y/%m/%d")
-  end
-
-  defp avatar_path(profile) do
-    if profile.avatar_path do
-      profile.avatar_path
-    else
-      ~p"/images/user_profile.svg"
-    end
-  end
-
-  defp avatar_bgcolor(username) do
-    ColorHash.hash(username) |> ColorHash.hsl_to_css()
   end
 end

--- a/lib/harmony_web/components/live/replies_component.ex
+++ b/lib/harmony_web/components/live/replies_component.ex
@@ -1,6 +1,11 @@
 defmodule HarmonyWeb.Components.RepliesComponent do
   use HarmonyWeb, :live_component
 
+  alias Harmony.Chat
+  alias Harmony.Chat.{Message, Reply}
+
+  import HarmonyWeb.ReplyComponents
+
   def render(assigns) do
     ~H"""
     <div class="relative">
@@ -26,38 +31,143 @@ defmodule HarmonyWeb.Components.RepliesComponent do
             <%= if assigns[:message] do %>
               <.message_item message={@message} dom_id="reply-base-message" threaded />
               <hr />
-              <div
-                :for={reply <- @message.replies}
-                class="group relative flex px-4 py-3 hover:bg-slate-100"
-              >
-                <img
-                  class="h-10 w-10 rounded shrink-0 bg-slate-300"
-                  style={"background-color: #{avatar_bgcolor(reply.user.username)};"}
-                  src={avatar_path(reply.user.profile)}
-                />
-                <div class="ml-2">
-                  <div class="-mt-1">
-                    <.link class="text-sm font-semibold hover:underline">
-                      <span class="message-user">{reply.user.username}</span>
-                    </.link>
-                    <span
-                      id={reply.id <> "timestamp"}
-                      phx-hook="Timestamp"
-                      data-timestamp={reply.inserted_at}
-                      class="ml-1 text-xs text-gray-500"
-                    >
-                      {message_timestamp(reply)}
-                    </span>
-                    <p class="text-sm message-body">{reply.body}</p>
+              <div id="replies-list" phx-update="stream">
+                <div
+                  :for={{dom_id, reply} <- @streams.replies}
+                  id={dom_id}
+                  class="group relative flex px-4 py-3 hover:bg-slate-100"
+                >
+                  <div class="join absolute top-4 right-4 hidden group-hover:inline-flex">
+                    <.reply_delete_button
+                      :if={@user.id == reply.user_id}
+                      reply={reply}
+                      target={@myself}
+                    />
+                  </div>
+                  <img
+                    class="h-10 w-10 rounded shrink-0 bg-slate-300"
+                    style={"background-color: #{avatar_bgcolor(reply.user.username)};"}
+                    src={avatar_path(reply.user.profile)}
+                  />
+                  <div class="ml-2">
+                    <div class="-mt-1">
+                      <.link class="text-sm font-semibold hover:underline">
+                        <span class="reply-user">{reply.user.username}</span>
+                      </.link>
+                      <span
+                        id={reply.id <> "timestamp"}
+                        phx-hook="Timestamp"
+                        data-timestamp={reply.inserted_at}
+                        class="ml-1 text-xs text-gray-500"
+                      >
+                        {message_timestamp(reply)}
+                      </span>
+                      <p class="text-sm reply-body">{reply.body}</p>
+                    </div>
                   </div>
                 </div>
               </div>
+              <.form
+                for={@form}
+                id="reply-send-form"
+                phx-submit="send-reply"
+                phx-change="validate-reply"
+                phx-target={@myself}
+                class="p-2 join"
+              >
+                <label for="chat-reply-textarea" class="sr-only">Reply Body</label>
+                <textarea
+                  class="textarea textarea-primary textarea-md join-item grow"
+                  id="chat-reply-textarea"
+                  name={@form[:body].name}
+                  placeholder={"Reply in ##{@room.name}"}
+                  phx-hook="CtrlEnterSubmit"
+                  phx-debounce
+                  rows="3"
+                >{Phoenix.HTML.Form.normalize_value("textarea", @form[:body].value)}</textarea>
+                <button class="btn btn-primary join-item h-full">
+                  <.icon name="hero-paper-airplane" class="h-4 w-4" />
+                </button>
+              </.form>
             <% end %>
           </div>
         </div>
       </div>
     </div>
     """
+  end
+
+  def update(%{new_reply: new_reply, message_id: message_id}, socket) do
+    if message_id == socket.assigns.message.id do
+      socket
+      |> stream_insert(:replies, new_reply)
+    else
+      socket
+    end
+    |> ok
+  end
+
+  def update(%{deleted_reply: deleted_reply, message_id: message_id}, socket) do
+    if message_id == socket.assigns.message.id do
+      socket
+      |> stream_delete(:replies, deleted_reply)
+    else
+      socket
+    end
+    |> ok
+  end
+
+  def update(%{message: %Message{} = message} = assigns, socket) do
+    replies = message.replies
+
+    changeset = Chat.change_reply(%Reply{})
+
+    socket
+    |> assign_reply_form(changeset)
+    |> assign(assigns)
+    |> stream(:replies, replies, reset: true)
+    |> ok
+  end
+
+  def update(assigns, socket) do
+    changeset = Chat.change_reply(%Reply{})
+
+    socket
+    |> assign_reply_form(changeset)
+    |> assign(assigns)
+    |> ok
+  end
+
+  def handle_event("validate-reply", _params, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("send-reply", %{"reply" => reply_params}, socket) do
+    user = socket.assigns.user
+    message = socket.assigns[:message]
+
+    case Chat.create_reply(user, message, reply_params) do
+      {:ok, %Reply{}} ->
+        changeset = Chat.change_reply(%Reply{body: ""})
+
+        socket
+        |> assign_reply_form(changeset)
+        |> noreply
+
+      {:error, changeset} ->
+        socket
+        |> assign_reply_form(changeset)
+        |> noreply
+    end
+  end
+
+  def handle_event("delete-reply", %{"id" => id}, socket) do
+    {:ok, %Chat.Reply{}} = Chat.delete_reply_by_id(id, socket.assigns.user)
+    {:noreply, socket}
+  end
+
+  defp assign_reply_form(socket, %Ecto.Changeset{} = changeset) do
+    assign(socket, :form, to_form(changeset))
   end
 
   defp message_timestamp(message) do

--- a/lib/harmony_web/components/live/replies_component.ex
+++ b/lib/harmony_web/components/live/replies_component.ex
@@ -23,7 +23,7 @@ defmodule HarmonyWeb.Components.RepliesComponent do
             phx-click="hide-replies"
           >
           </div>
-          <div class="menu bg-white w-5/6 md:w-1/3 h-full">
+          <div class="menu bg-white w-5/6 md:w-1/3 h-full flex flex-col flex-nowrap">
             <div :if={@room} class="header border-b pb-3">
               <h2 class="font-bold">Replies</h2>
               <div>#{@room.name}</div>
@@ -31,7 +31,7 @@ defmodule HarmonyWeb.Components.RepliesComponent do
             <%= if assigns[:message] do %>
               <.message_item message={@message} dom_id="reply-base-message" threaded />
               <hr />
-              <div id="replies-list" phx-update="stream">
+              <div id="replies-list" phx-update="stream" class="overflow-y-auto">
                 <.reply_item
                   :for={{dom_id, reply} <- @streams.replies}
                   dom_id={dom_id}
@@ -40,7 +40,7 @@ defmodule HarmonyWeb.Components.RepliesComponent do
                   delete_target={@myself}
                 />
               </div>
-              <.send_reply_form form={@form} target={@myself} room={@room} />
+              <.send_reply_form form={@form} target={@myself} room={@room} class="w-full" />
             <% end %>
           </div>
         </div>

--- a/lib/harmony_web/components/live/replies_component.ex
+++ b/lib/harmony_web/components/live/replies_component.ex
@@ -25,11 +25,54 @@ defmodule HarmonyWeb.Components.RepliesComponent do
             </div>
             <%= if assigns[:message] do %>
               <.message_item message={@message} dom_id="reply-base-message" threaded />
+              <hr />
+              <div
+                :for={reply <- @message.replies}
+                class="group relative flex px-4 py-3 hover:bg-slate-100"
+              >
+                <img
+                  class="h-10 w-10 rounded shrink-0 bg-slate-300"
+                  style={"background-color: #{avatar_bgcolor(reply.user.username)};"}
+                  src={avatar_path(reply.user.profile)}
+                />
+                <div class="ml-2">
+                  <div class="-mt-1">
+                    <.link class="text-sm font-semibold hover:underline">
+                      <span class="message-user">{reply.user.username}</span>
+                    </.link>
+                    <span
+                      id={reply.id <> "timestamp"}
+                      phx-hook="Timestamp"
+                      data-timestamp={reply.inserted_at}
+                      class="ml-1 text-xs text-gray-500"
+                    >
+                      {message_timestamp(reply)}
+                    </span>
+                    <p class="text-sm message-body">{reply.body}</p>
+                  </div>
+                </div>
+              </div>
             <% end %>
           </div>
         </div>
       </div>
     </div>
     """
+  end
+
+  defp message_timestamp(message) do
+    message.inserted_at |> Calendar.strftime("%I:%M %p on %Y/%m/%d")
+  end
+
+  defp avatar_path(profile) do
+    if profile.avatar_path do
+      profile.avatar_path
+    else
+      ~p"/images/user_profile.svg"
+    end
+  end
+
+  defp avatar_bgcolor(username) do
+    ColorHash.hash(username) |> ColorHash.hsl_to_css()
   end
 end

--- a/lib/harmony_web/components/live/replies_component.ex
+++ b/lib/harmony_web/components/live/replies_component.ex
@@ -50,7 +50,7 @@ defmodule HarmonyWeb.Components.RepliesComponent do
   end
 
   def update(%{new_reply: new_reply, message_id: message_id}, socket) do
-    if message_id == socket.assigns.message.id do
+    if socket.assigns.message && message_id == socket.assigns.message.id do
       socket
       |> stream_insert(:replies, new_reply)
     else
@@ -60,7 +60,7 @@ defmodule HarmonyWeb.Components.RepliesComponent do
   end
 
   def update(%{deleted_reply: deleted_reply, message_id: message_id}, socket) do
-    if message_id == socket.assigns.message.id do
+    if socket.assigns.message && message_id == socket.assigns.message.id do
       socket
       |> stream_delete(:replies, deleted_reply)
     else

--- a/lib/harmony_web/components/message_components.ex
+++ b/lib/harmony_web/components/message_components.ex
@@ -40,13 +40,16 @@ defmodule HarmonyWeb.MessageComponents do
 
   def message_item(assigns) do
     user = assigns.message.user
-    profile = Harmony.Accounts.get_user_profile(user)
+    profile = user.profile
 
     assigns = assign(assigns, profile: profile, user: user)
 
     ~H"""
     <div id={@dom_id} class="group relative flex px-4 py-3 hover:bg-slate-100">
-      <.message_delete_button :if={@show_delete} message={@message} />
+      <div class="join absolute top-4 right-4 hidden group-hover:inline-flex">
+        <.message_delete_button :if={@show_delete} message={@message} />
+        <.message_reply_button message={@message} />
+      </div>
       <img
         class="h-10 w-10 rounded shrink-0 bg-slate-300"
         style={"background-color: #{avatar_bgcolor(@user.username)};"}
@@ -79,14 +82,6 @@ defmodule HarmonyWeb.MessageComponents do
           </span>
           <p class="text-sm message-body">{@message.body}</p>
         </div>
-        <div
-          :if={!@threaded}
-          id={@dom_id <> "-replies-btn"}
-          phx-click="show-replies"
-          phx-value-message_id={@message.id}
-        >
-          Replies
-        </div>
       </div>
     </div>
     """
@@ -110,10 +105,23 @@ defmodule HarmonyWeb.MessageComponents do
       phx-click="delete-message"
       phx-value-id={@message.id}
       data-confirm="Are you sure?"
-      class="absolute top-4 right-4 text-red-500 hover:text-red-800 cursor-pointer hidden group-hover:block"
+      class="btn btn-error btn-sm join-item cursor-pointer"
     >
       <.icon name="hero-trash" class="h-4 w-4" />
       <div class="sr-only">Delete</div>
+    </button>
+    """
+  end
+
+  defp message_reply_button(assigns) do
+    ~H"""
+    <button
+      class="btn btn-sm btn-info btn-soft join-item cursor-pointer"
+      phx-click="show-replies"
+      phx-value-message_id={@message.id}
+    >
+      <.icon name="hero-arrow-uturn-left" class="h-4 w-4" />
+      <div class="sr-only">Show replies</div>
     </button>
     """
   end

--- a/lib/harmony_web/components/message_components.ex
+++ b/lib/harmony_web/components/message_components.ex
@@ -82,6 +82,8 @@ defmodule HarmonyWeb.MessageComponents do
           </span>
           <p class="text-sm message-body">{@message.body}</p>
         </div>
+
+        <.reply_avatar_group :if={@message.replies} replies={@message.replies} />
       </div>
     </div>
     """
@@ -141,4 +143,41 @@ defmodule HarmonyWeb.MessageComponents do
   defp avatar_bgcolor(username) do
     ColorHash.hash(username) |> ColorHash.hsl_to_css()
   end
+
+  attr :replies, :list, default: []
+
+  def reply_avatar_group(assigns) do
+    users =
+      assigns.replies
+      |> Enum.map(& &1.user)
+      |> Enum.uniq_by(& &1.id)
+
+    assigns = assign(assigns, :users, users)
+
+    ~H"""
+    <div :if={length(@replies) > 0} class="avatar-group -space-x-4">
+      <div :for={user <- @users} class="avatar">
+        <div class="w-6">
+          <img
+            src={avatar_path(user.profile)}
+            style={"background-color: #{avatar_bgcolor(user.username)};"}
+          />
+        </div>
+      </div>
+      <div class="avatar avatar-placeholder">
+        <div class="bg-neutral text-neutral-content w-6">
+          <span>+{length(@replies)}</span>
+          <div class="span sr-only">
+            {pluralize_replies_from_users(replies: length(@replies), users: length(@users))}
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp pluralize_replies_from_users(replies: 1, users: 1), do: "1 reply from 1 user"
+  defp pluralize_replies_from_users(replies: 1, users: n), do: "1 reply from #{n} users"
+  defp pluralize_replies_from_users(replies: n, users: 1), do: "#{n} replies from 1 user"
+  defp pluralize_replies_from_users(replies: n, users: m), do: "#{n} replies from #{m} users"
 end

--- a/lib/harmony_web/components/message_components.ex
+++ b/lib/harmony_web/components/message_components.ex
@@ -9,12 +9,12 @@ defmodule HarmonyWeb.MessageComponents do
   import HarmonyWeb.CoreComponents
 
   alias Harmony.Chat.Message
-  # alias Phoenix.LiveView.JS
 
   # attr :message, Message OR :unread_marker
   attr :message, :any, required: true
   attr :show_delete, :boolean, default: false
   attr :dom_id, :string
+  attr :threaded, :boolean, default: false
 
   def message_item(%{message: {:date_divider, date}} = assigns) do
     assigns = assign(assigns, :date, date)
@@ -54,6 +54,7 @@ defmodule HarmonyWeb.MessageComponents do
         phx-click={show("#msg-#{@message.id}-profile")}
       />
       <.live_component
+        :if={!@threaded}
         module={HarmonyWeb.Components.ProfileComponent}
         id={"msg-#{@message.id}-profile"}
         profile={@profile}
@@ -77,6 +78,14 @@ defmodule HarmonyWeb.MessageComponents do
             {message_timestamp(@message)}
           </span>
           <p class="text-sm message-body">{@message.body}</p>
+        </div>
+        <div
+          :if={!@threaded}
+          id={@dom_id <> "-replies-btn"}
+          phx-click="show-replies"
+          phx-value-message_id={@message.id}
+        >
+          Replies
         </div>
       </div>
     </div>

--- a/lib/harmony_web/components/reply_components.ex
+++ b/lib/harmony_web/components/reply_components.ex
@@ -1,0 +1,31 @@
+defmodule HarmonyWeb.ReplyComponents do
+  @moduledoc """
+  Provides UI components for Chat.Reply items in the RepliesComponent 
+  ive component
+  """
+  use Phoenix.Component
+  use Gettext, backend: HarmonyWeb.Gettext
+  use HarmonyWeb, :verified_routes
+
+  alias Harmony.Chat.Reply
+
+  import HarmonyWeb.CoreComponents
+
+  attr :reply, Reply, required: true
+  attr :target, Phoenix.LiveComponent.CID, default: nil
+
+  def reply_delete_button(assigns) do
+    ~H"""
+    <button
+      phx-click="delete-reply"
+      phx-value-id={@reply.id}
+      phx-target={@target}
+      data-confirm="Are you sure?"
+      class="btn btn-error btn-sm join-item cursor-pointer"
+    >
+      <.icon name="hero-trash" class="h-4 w-4" />
+      <div class="sr-only">Delete</div>
+    </button>
+    """
+  end
+end

--- a/lib/harmony_web/components/reply_components.ex
+++ b/lib/harmony_web/components/reply_components.ex
@@ -12,6 +12,73 @@ defmodule HarmonyWeb.ReplyComponents do
   import HarmonyWeb.CoreComponents
 
   attr :reply, Reply, required: true
+  attr :dom_id, :string
+  attr :show_delete, :boolean, default: false
+  attr :delete_target, Phoenix.LiveComponent.CID, default: nil
+
+  def reply_item(assigns) do
+    ~H"""
+    <div id={@dom_id} class="group relative flex px-4 py-3 hover:bg-slate-100">
+      <div class="join absolute top-4 right-4 hidden group-hover:inline-flex">
+        <.reply_delete_button :if={@show_delete} reply={@reply} target={@delete_target} />
+      </div>
+      <img
+        class="h-10 w-10 rounded shrink-0 bg-slate-300"
+        style={"background-color: #{avatar_bgcolor(@reply.user.username)};"}
+        src={avatar_path(@reply.user.profile)}
+      />
+      <div class="ml-2">
+        <div class="-mt-1">
+          <.link class="text-sm font-semibold hover:underline">
+            <span class="reply-user">{@reply.user.username}</span>
+          </.link>
+          <span
+            id={@reply.id <> "timestamp"}
+            phx-hook="Timestamp"
+            data-timestamp={@reply.inserted_at}
+            class="ml-1 text-xs text-gray-500"
+          >
+            {reply_timestamp(@reply)}
+          </span>
+          <p class="text-sm reply-body">{@reply.body}</p>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :form, Phoenix.HTML.Form, required: true
+  attr :target, Phoenix.LiveComponent.CID, default: nil
+  attr :room, Harmony.Chat.Room, required: true
+
+  def send_reply_form(assigns) do
+    ~H"""
+    <.form
+      for={@form}
+      id="reply-send-form"
+      phx-submit="send-reply"
+      phx-change="validate-reply"
+      phx-target={@target}
+      class="p-2 join"
+    >
+      <label for="chat-reply-textarea" class="sr-only">Reply Body</label>
+      <textarea
+        class="textarea textarea-primary textarea-md join-item grow"
+        id="chat-reply-textarea"
+        name={@form[:body].name}
+        placeholder={"Reply in ##{@room.name}"}
+        phx-hook="CtrlEnterSubmit"
+        phx-debounce
+        rows="3"
+      >{Phoenix.HTML.Form.normalize_value("textarea", @form[:body].value)}</textarea>
+      <button class="btn btn-primary join-item h-full">
+        <.icon name="hero-paper-airplane" class="h-4 w-4" />
+      </button>
+    </.form>
+    """
+  end
+
+  attr :reply, Reply, required: true
   attr :target, Phoenix.LiveComponent.CID, default: nil
 
   def reply_delete_button(assigns) do
@@ -27,5 +94,21 @@ defmodule HarmonyWeb.ReplyComponents do
       <div class="sr-only">Delete</div>
     </button>
     """
+  end
+
+  defp avatar_path(profile) do
+    if profile.avatar_path do
+      profile.avatar_path
+    else
+      ~p"/images/user_profile.svg"
+    end
+  end
+
+  defp avatar_bgcolor(username) do
+    ColorHash.hash(username) |> ColorHash.hsl_to_css()
+  end
+
+  defp reply_timestamp(reply) do
+    reply.inserted_at |> Calendar.strftime("%I:%M %p on %Y/%m/%d")
   end
 end

--- a/lib/harmony_web/components/reply_components.ex
+++ b/lib/harmony_web/components/reply_components.ex
@@ -50,6 +50,7 @@ defmodule HarmonyWeb.ReplyComponents do
   attr :form, Phoenix.HTML.Form, required: true
   attr :target, Phoenix.LiveComponent.CID, default: nil
   attr :room, Harmony.Chat.Room, required: true
+  attr :class, :string, default: ""
 
   def send_reply_form(assigns) do
     ~H"""
@@ -59,7 +60,7 @@ defmodule HarmonyWeb.ReplyComponents do
       phx-submit="send-reply"
       phx-change="validate-reply"
       phx-target={@target}
-      class="p-2 join"
+      class={["p-2 join join-horizontal", @class]}
     >
       <label for="chat-reply-textarea" class="sr-only">Reply Body</label>
       <textarea
@@ -71,7 +72,7 @@ defmodule HarmonyWeb.ReplyComponents do
         phx-debounce
         rows="3"
       >{Phoenix.HTML.Form.normalize_value("textarea", @form[:body].value)}</textarea>
-      <button class="btn btn-primary join-item h-full">
+      <button class="btn btn-primary join-item h-auto w-auto">
         <.icon name="hero-paper-airplane" class="h-4 w-4" />
       </button>
     </.form>

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -4,7 +4,7 @@ defmodule HarmonyWeb.ChatRoomLive do
   alias Harmony.Accounts
   alias Harmony.Chat
   alias Harmony.Chat.Message
-  alias HarmonyWeb.Components.{RoomEditComponent, RoomIndexComponent}
+  alias HarmonyWeb.Components.{RepliesComponent, RoomEditComponent, RoomIndexComponent}
   alias HarmonyWeb.OnlineUsers
 
   def render(assigns) do
@@ -66,6 +66,12 @@ defmodule HarmonyWeb.ChatRoomLive do
       <.users_list_actions :if={@sidebar_right} current_user={@current_user} />
     </div>
 
+    <.live_component
+      id="replies-component"
+      module={RepliesComponent}
+      message={@replies_parent}
+      room={@room}
+    />"
     <%= if @current_user.role == :admin do %>
       <!-- Room modals -->
       <%= if @room do %>
@@ -103,6 +109,7 @@ defmodule HarmonyWeb.ChatRoomLive do
     |> assign(users: users)
     |> assign(:sidebar_left, true)
     |> assign(:sidebar_right, true)
+    |> assign(:replies_parent, nil)
     |> stream_configure(:messages,
       dom_id: fn
         %Chat.Message{id: id} -> "messages-#{id}"
@@ -190,6 +197,20 @@ defmodule HarmonyWeb.ChatRoomLive do
 
     socket
     |> assign(:rooms, Chat.list_joined_rooms_with_unread_counts(socket.assigns.current_user))
+    |> noreply
+  end
+
+  def handle_event("show-replies", %{"message_id" => message_id}, socket) do
+    message = Chat.get_message(message_id)
+
+    socket
+    |> assign(replies_parent: message)
+    |> noreply
+  end
+
+  def handle_event("hide-replies", _params, socket) do
+    socket
+    |> assign(replies_parent: nil)
     |> noreply
   end
 

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -208,7 +208,11 @@ defmodule HarmonyWeb.ChatRoomLive do
       message_id: message_id
     )
 
-    {:noreply, socket}
+    message = Chat.get_message_with_replies(message_id)
+
+    socket
+    |> stream_insert(:messages, message)
+    |> noreply
   end
 
   def handle_info({:delete_reply, message_id, %Chat.Reply{} = reply}, socket) do
@@ -218,7 +222,11 @@ defmodule HarmonyWeb.ChatRoomLive do
       message_id: message_id
     )
 
-    {:noreply, socket}
+    message = Chat.get_message_with_replies(message_id)
+
+    socket
+    |> stream_insert(:messages, message)
+    |> noreply
   end
 
   def handle_event("show-replies", %{"message_id" => message_id}, socket) do

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -201,30 +201,20 @@ defmodule HarmonyWeb.ChatRoomLive do
     |> noreply
   end
 
-  def handle_info({:new_reply, message_id, %Chat.Reply{} = reply}, socket) do
-    send_update(RepliesComponent,
-      id: "replies-component",
-      new_reply: reply,
-      message_id: message_id
-    )
-
+  def handle_info({:new_reply, message_id, _reply}, socket) do
     message = Chat.get_message_with_replies(message_id)
 
     socket
+    |> maybe_update_replies_parent(message)
     |> stream_insert(:messages, message)
     |> noreply
   end
 
-  def handle_info({:delete_reply, message_id, %Chat.Reply{} = reply}, socket) do
-    send_update(RepliesComponent,
-      id: "replies-component",
-      deleted_reply: reply,
-      message_id: message_id
-    )
-
+  def handle_info({:delete_reply, message_id, _reply}, socket) do
     message = Chat.get_message_with_replies(message_id)
 
     socket
+    |> maybe_update_replies_parent(message)
     |> stream_insert(:messages, message)
     |> noreply
   end
@@ -358,6 +348,14 @@ defmodule HarmonyWeb.ChatRoomLive do
 
     if new_room && !Chat.joined?(new_room, user) do
       Chat.subscribe_to_room(new_room)
+    end
+  end
+
+  defp maybe_update_replies_parent(socket, message) do
+    if socket.assigns[:replies_parent] && socket.assigns.replies_parent.id == message.id do
+      assign(socket, :replies_parent, message)
+    else
+      socket
     end
   end
 end

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -43,7 +43,7 @@ defmodule HarmonyWeb.ChatRoomLive do
             :for={{dom_id, message} <- @streams.messages}
             dom_id={dom_id}
             message={message}
-            show_delete={is_struct(message) && @current_user == message.user}
+            show_delete={is_struct(message) && @current_user.id == message.user.id}
           />
         </div>
         <.message_send_form
@@ -201,7 +201,7 @@ defmodule HarmonyWeb.ChatRoomLive do
   end
 
   def handle_event("show-replies", %{"message_id" => message_id}, socket) do
-    message = Chat.get_message(message_id)
+    message = Chat.get_message_with_replies(message_id)
 
     socket
     |> assign(replies_parent: message)

--- a/lib/harmony_web/live/chat_room_live.ex
+++ b/lib/harmony_web/live/chat_room_live.ex
@@ -70,6 +70,7 @@ defmodule HarmonyWeb.ChatRoomLive do
       id="replies-component"
       module={RepliesComponent}
       message={@replies_parent}
+      user={@current_user}
       room={@room}
     />"
     <%= if @current_user.role == :admin do %>
@@ -198,6 +199,26 @@ defmodule HarmonyWeb.ChatRoomLive do
     socket
     |> assign(:rooms, Chat.list_joined_rooms_with_unread_counts(socket.assigns.current_user))
     |> noreply
+  end
+
+  def handle_info({:new_reply, message_id, %Chat.Reply{} = reply}, socket) do
+    send_update(RepliesComponent,
+      id: "replies-component",
+      new_reply: reply,
+      message_id: message_id
+    )
+
+    {:noreply, socket}
+  end
+
+  def handle_info({:delete_reply, message_id, %Chat.Reply{} = reply}, socket) do
+    send_update(RepliesComponent,
+      id: "replies-component",
+      deleted_reply: reply,
+      message_id: message_id
+    )
+
+    {:noreply, socket}
   end
 
   def handle_event("show-replies", %{"message_id" => message_id}, socket) do

--- a/priv/repo/migrations/20250226221303_create_replies.exs
+++ b/priv/repo/migrations/20250226221303_create_replies.exs
@@ -1,0 +1,17 @@
+defmodule Harmony.Repo.Migrations.CreateReplies do
+  use Ecto.Migration
+
+  def change do
+    create table(:replies, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :body, :text, null: false
+      add :message_id, references(:messages, on_delete: :delete_all, type: :binary_id)
+      add :user_id, references(:users, on_delete: :nilify_all, type: :binary_id)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:replies, [:message_id])
+    create index(:replies, [:user_id])
+  end
+end

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -301,4 +301,67 @@ defmodule Harmony.ChatTest do
       assert [%Chat.Message{id: ^id}] = Chat.list_messages(room)
     end
   end
+
+  describe "replies" do
+    test "list_replies" do
+      message = insert(:message)
+      [r1, r2] = insert_pair(:reply, message: message)
+      insert_pair(:reply)
+      [id1, id2] = [r1.id, r2.id]
+
+      assert [%Chat.Reply{id: ^id1}, %Chat.Reply{id: ^id2}] =
+               Chat.list_replies(message.id)
+    end
+
+    test "change_reply/2 returns a valid changeset" do
+      user = user_fixture()
+      message = insert(:message)
+      reply = %Chat.Reply{message: message, user: user}
+      new_attrs = %{body: "reply body"}
+
+      assert changeset = %Ecto.Changeset{} = Chat.change_reply(reply, new_attrs)
+      assert changeset.changes.body == "reply body"
+      assert changeset.valid?
+    end
+
+    test "create_reply/3 creates a reply" do
+      user = user_fixture()
+      message = insert(:message)
+      params = %{body: "First reply!"}
+      Chat.subscribe_to_room(message.room)
+      message_id = message.id
+
+      assert {:ok, reply} = Chat.create_reply(user, message, params)
+      assert_receive({:new_reply, ^message_id, ^reply})
+      assert reply.body == "First reply!"
+    end
+  end
+
+  test "delete_reply_by_id/2 delete a message with id && user" do
+    user = user_fixture()
+    message = insert(:message)
+    reply = insert(:reply, user: user, message: message)
+    id = reply.id
+    mid = message.id
+    Chat.subscribe_to_room(message.room)
+
+    assert [%Chat.Reply{id: ^id}] = Chat.list_replies(message.id)
+    assert {:ok, %Chat.Reply{}} = Chat.delete_reply_by_id(id, user)
+    assert_receive({:delete_reply, ^mid, %Chat.Reply{id: ^id}})
+    assert [] == Chat.list_replies(message.id)
+  end
+
+  test "delete_reply_by_id/2 does not delete a message with wrong user" do
+    user = user_fixture()
+    message = insert(:message)
+    reply = insert(:reply, message: message)
+    id = reply.id
+    mid = message.id
+    Chat.subscribe_to_room(message.room)
+
+    assert [%Chat.Reply{id: ^id}] = Chat.list_replies(message.id)
+    assert {:error, _} = Chat.delete_reply_by_id(id, user)
+    refute_receive({:delete_reply, ^mid, %Chat.Reply{id: ^id}})
+    assert [%Chat.Reply{id: ^id}] = Chat.list_replies(message.id)
+  end
 end

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -212,8 +212,9 @@ defmodule Harmony.ChatTest do
       id = msg.id
 
       assert %Chat.Message{id: ^id} = message = Chat.get_message(msg.id)
-      # Assert the user is preloaded
+      # Assert the user and their is preloaded
       assert %Harmony.Accounts.User{} = message.user
+      assert %Harmony.Accounts.Profile{} = message.user.profile
     end
 
     test "get_message_with_replies/1 gets a message by id" do
@@ -226,6 +227,7 @@ defmodule Harmony.ChatTest do
       assert %Chat.Message{id: ^id} = message = Chat.get_message_with_replies(msg.id)
       # Assert the user and replies are is preloaded
       assert %Harmony.Accounts.User{} = message.user
+      assert %Harmony.Accounts.Profile{} = message.user.profile
       assert length(message.replies) == 2
     end
 

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -207,6 +207,28 @@ defmodule Harmony.ChatTest do
   end
 
   describe "messages" do
+    test "get_message/1 gets a message by id" do
+      msg = insert(:message)
+      id = msg.id
+
+      assert %Chat.Message{id: ^id} = message = Chat.get_message(msg.id)
+      # Assert the user is preloaded
+      assert %Harmony.Accounts.User{} = message.user
+    end
+
+    test "get_message_with_replies/1 gets a message by id" do
+      msg =
+        insert(:message)
+        |> with_replies(count: 2)
+
+      id = msg.id
+
+      assert %Chat.Message{id: ^id} = message = Chat.get_message_with_replies(msg.id)
+      # Assert the user and replies are is preloaded
+      assert %Harmony.Accounts.User{} = message.user
+      assert length(message.replies) == 2
+    end
+
     test "list_messages/1 returns all messages for a room" do
       room = insert(:room)
       insert_list(3, :message, room: room)

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -306,16 +306,6 @@ defmodule Harmony.ChatTest do
   end
 
   describe "replies" do
-    test "list_replies" do
-      message = insert(:message)
-      [r1, r2] = insert_pair(:reply, message: message)
-      insert_pair(:reply)
-      [id1, id2] = [r1.id, r2.id]
-
-      assert [%Chat.Reply{id: ^id1}, %Chat.Reply{id: ^id2}] =
-               Chat.list_replies(message.id)
-    end
-
     test "change_reply/2 returns a valid changeset" do
       user = user_fixture()
       message = insert(:message)
@@ -348,10 +338,9 @@ defmodule Harmony.ChatTest do
     mid = message.id
     Chat.subscribe_to_room(message.room)
 
-    assert [%Chat.Reply{id: ^id}] = Chat.list_replies(message.id)
     assert {:ok, %Chat.Reply{}} = Chat.delete_reply_by_id(id, user)
     assert_receive({:delete_reply, ^mid, %Chat.Reply{id: ^id}})
-    assert [] == Chat.list_replies(message.id)
+    assert Chat.get_message_with_replies(mid).replies == []
   end
 
   test "delete_reply_by_id/2 does not delete a message with wrong user" do
@@ -362,9 +351,8 @@ defmodule Harmony.ChatTest do
     mid = message.id
     Chat.subscribe_to_room(message.room)
 
-    assert [%Chat.Reply{id: ^id}] = Chat.list_replies(message.id)
     assert {:error, _} = Chat.delete_reply_by_id(id, user)
     refute_receive({:delete_reply, ^mid, %Chat.Reply{id: ^id}})
-    assert [%Chat.Reply{id: ^id}] = Chat.list_replies(message.id)
+    assert [%Chat.Reply{id: ^id}] = Chat.get_message_with_replies(mid).replies
   end
 end

--- a/test/harmony/chat_test.exs
+++ b/test/harmony/chat_test.exs
@@ -238,8 +238,11 @@ defmodule Harmony.ChatTest do
       other_room = insert(:room)
       insert_list(3, :message, room: other_room)
 
-      messages = Chat.list_messages(room)
+      [m1 | _] = messages = Chat.list_messages(room)
       assert length(messages) == 3
+
+      # We need the replies preloaded
+      assert is_list(m1.replies)
     end
 
     test "create_message/3 create a message" do

--- a/test/harmony_web/feature/user_can_delete_messages_test.exs
+++ b/test/harmony_web/feature/user_can_delete_messages_test.exs
@@ -27,6 +27,6 @@ defmodule HarmonyWeb.UsersCanDeleteMessages do
     conn
     |> visit("/rooms/#{room.name}")
     |> assert_has("#messages-#{m.id}")
-    |> refute_has("#messages-#{m.id} button")
+    |> refute_has("#messages-#{m.id} button", text: "Delete")
   end
 end

--- a/test/harmony_web/feature/user_can_send_messages_test.exs
+++ b/test/harmony_web/feature/user_can_send_messages_test.exs
@@ -1,4 +1,4 @@
-defmodule HarmonyWeb.UsersCanSendMessages do
+defmodule HarmonyWeb.UsersCanSendMessagesTest do
   use HarmonyWeb.FeatureCase, async: true
   import Harmony.Factory
   import Harmony.AccountsFixtures

--- a/test/harmony_web/feature/users-have-unread-markers_test.exs
+++ b/test/harmony_web/feature/users-have-unread-markers_test.exs
@@ -65,7 +65,7 @@ defmodule HarmonyWeb.UsersHaveUnreadMarkersTest do
 
     conn = visit(conn, "/rooms/#{room.name}")
     # The actual exercise - sending a new message
-    m4 = insert(:message, room: room)
+    m4 = insert(:message, room: room) |> Harmony.Repo.preload(user: :profile)
     send(conn.view.pid, {:new_message, m4})
     # Need to use the conn again to get it to process the message
     assert_has(conn, ".message-body", text: m4.body)

--- a/test/harmony_web/feature/users-have-unread-markers_test.exs
+++ b/test/harmony_web/feature/users-have-unread-markers_test.exs
@@ -65,7 +65,10 @@ defmodule HarmonyWeb.UsersHaveUnreadMarkersTest do
 
     conn = visit(conn, "/rooms/#{room.name}")
     # The actual exercise - sending a new message
-    m4 = insert(:message, room: room) |> Harmony.Repo.preload(user: :profile)
+    m4 =
+      insert(:message, room: room)
+      |> Harmony.Repo.preload(user: :profile, replies: [user: :profile])
+
     send(conn.view.pid, {:new_message, m4})
     # Need to use the conn again to get it to process the message
     assert_has(conn, ".message-body", text: m4.body)

--- a/test/harmony_web/feature/users_can_join_rooms_as_members_test.exs
+++ b/test/harmony_web/feature/users_can_join_rooms_as_members_test.exs
@@ -75,7 +75,7 @@ defmodule HarmonyWeb.UsersCanJoinRoomsAsMembersTest do
 
   defp send_message(conn, room, attrs) do
     attrs = Keyword.merge(attrs, room: room)
-    msg = insert(:message, attrs)
+    msg = insert(:message, attrs) |> Harmony.Repo.preload(user: :profile)
     Phoenix.PubSub.broadcast(Harmony.PubSub, topic(room.id), {:new_message, msg})
     conn
   end

--- a/test/harmony_web/feature/users_can_join_rooms_as_members_test.exs
+++ b/test/harmony_web/feature/users_can_join_rooms_as_members_test.exs
@@ -75,7 +75,10 @@ defmodule HarmonyWeb.UsersCanJoinRoomsAsMembersTest do
 
   defp send_message(conn, room, attrs) do
     attrs = Keyword.merge(attrs, room: room)
-    msg = insert(:message, attrs) |> Harmony.Repo.preload(user: :profile)
+
+    msg =
+      insert(:message, attrs) |> Harmony.Repo.preload(user: :profile, replies: [user: :profile])
+
     Phoenix.PubSub.broadcast(Harmony.PubSub, topic(room.id), {:new_message, msg})
     conn
   end

--- a/test/harmony_web/feature/users_can_send_replies_test.exs
+++ b/test/harmony_web/feature/users_can_send_replies_test.exs
@@ -1,0 +1,89 @@
+defmodule HarmonyWeb.UsersCanSendRepliessTest do
+  use HarmonyWeb.FeatureCase, async: true
+  import Harmony.Factory
+  import Harmony.AccountsFixtures
+
+  alias Harmony.Chat
+
+  setup :register_and_log_in_user
+
+  setup %{conn: conn, user: user} do
+    room = insert(:room)
+    message = insert(:message, room: room)
+    %{conn: conn, user: user, room: room, message: message}
+  end
+
+  test "users can send replies to messages", %{
+    conn: conn,
+    user: user,
+    room: room,
+    message: message
+  } do
+    Chat.join_room!(room, user)
+
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> click_button("#messages-#{message.id} button", "Show replies")
+    |> fill_in("#reply-send-form textarea", "Reply Body", with: "Test reply body")
+    |> submit()
+    |> assert_has("#replies-list .reply-body", text: "Test reply body")
+    |> assert_has("#replies-list .reply-user", text: user.username)
+  end
+
+  test "users can delete their own replies", %{
+    conn: conn,
+    user: user,
+    room: room,
+    message: message
+  } do
+    Chat.join_room!(room, user)
+    reply = insert(:reply, message: message, user: user)
+
+    conn
+    |> visit("/rooms/#{room.name}")
+    |> click_button("#messages-#{message.id} button", "Show replies")
+    |> assert_has("#replies-list .reply-body", text: reply.body)
+    |> click_button("#replies-#{reply.id} button", "Delete")
+    |> refute_has("#replies-list .reply-body", text: reply.body)
+  end
+
+  test "users can see other users replies in real time", %{
+    conn: conn,
+    room: room,
+    message: message
+  } do
+    user1 = user_fixture()
+    user2 = user_fixture()
+
+    session1 =
+      conn
+      |> log_in_user(user1)
+      |> visit("/rooms/#{room.name}")
+      |> click_button("#messages-#{message.id} button", "Show replies")
+
+    # in a separate session, user2 also logs in and sends a reply
+    session2 =
+      conn
+      |> log_in_user(user2)
+      |> visit("/rooms/#{room.name}")
+      |> click_button("#messages-#{message.id} button", "Show replies")
+      |> fill_in("#reply-send-form textarea", "Reply Body", with: "Test reply body")
+      |> submit()
+
+    # user1 sees the reply pop up
+    session1 =
+      session1
+      |> assert_has("#replies-list .reply-body", text: "Test reply body")
+      |> assert_has("#replies-list .reply-user", text: user2.username)
+
+    reply = Chat.list_replies(message.id) |> List.first()
+
+    # user2 deletes their reply
+    session2
+    |> click_button("#replies-#{reply.id} button", "Delete")
+
+    # user1 sees the reply disappear
+    session1
+    |> refute_has("#replies-list .reply-body", text: "Test reply body")
+  end
+end

--- a/test/harmony_web/feature/users_can_send_replies_test.exs
+++ b/test/harmony_web/feature/users_can_send_replies_test.exs
@@ -76,7 +76,7 @@ defmodule HarmonyWeb.UsersCanSendRepliessTest do
       |> assert_has("#replies-list .reply-body", text: "Test reply body")
       |> assert_has("#replies-list .reply-user", text: user2.username)
 
-    reply = Chat.list_replies(message.id) |> List.first()
+    [reply] = Chat.get_message_with_replies(message.id).replies
 
     # user2 deletes their reply
     session2
@@ -112,7 +112,7 @@ defmodule HarmonyWeb.UsersCanSendRepliessTest do
       |> fill_in("#reply-send-form textarea", "Reply Body", with: "Test reply body again")
       |> submit()
 
-    [reply1, reply2] = Chat.list_replies(message.id)
+    [reply1, reply2] = Chat.get_message_with_replies(message.id).replies
 
     # user1 sees an avatar-group pop up under the message with a count
     session1 =

--- a/test/harmony_web/feature/users_can_send_replies_test.exs
+++ b/test/harmony_web/feature/users_can_send_replies_test.exs
@@ -86,4 +86,59 @@ defmodule HarmonyWeb.UsersCanSendRepliessTest do
     session1
     |> refute_has("#replies-list .reply-body", text: "Test reply body")
   end
+
+  test "replies appear as avatar groups in real time", %{
+    conn: conn,
+    room: room,
+    message: message
+  } do
+    user1 = user_fixture()
+    user2 = user_fixture()
+
+    session1 =
+      conn
+      |> log_in_user(user1)
+      |> visit("/rooms/#{room.name}")
+      |> refute_has("#messages-list #messages-#{message.id} .avatar-group")
+
+    # in a separate session, user2 also logs in and sends two replies
+    session2 =
+      conn
+      |> log_in_user(user2)
+      |> visit("/rooms/#{room.name}")
+      |> click_button("#messages-#{message.id} button", "Show replies")
+      |> fill_in("#reply-send-form textarea", "Reply Body", with: "Test reply body")
+      |> submit()
+      |> fill_in("#reply-send-form textarea", "Reply Body", with: "Test reply body again")
+      |> submit()
+
+    [reply1, reply2] = Chat.list_replies(message.id)
+
+    # user1 sees an avatar-group pop up under the message with a count
+    session1 =
+      session1
+      |> assert_has("#messages-list #messages-#{message.id} .avatar-group",
+        text: "2 replies from 1 user"
+      )
+
+    # user2 deletes a reply
+    session2 =
+      session2
+      |> click_button("#replies-#{reply1.id} button", "Delete")
+
+    # user1 sees the reply count decrement
+    session1 =
+      session1
+      |> assert_has("#messages-list #messages-#{message.id} .avatar-group",
+        text: "1 reply from 1 user"
+      )
+
+    # user2 deletes their other reply
+    session2
+    |> click_button("#replies-#{reply2.id} button", "Delete")
+
+    # user1 sees the avatar-group disappear
+    session1
+    |> refute_has("#messages-list #messages-#{message.id} .avatar-group")
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,6 +4,7 @@ defmodule Harmony.Factory do
 
   alias Harmony.Accounts.User
   alias Harmony.Chat.Room
+  alias Harmony.Chat.Message
 
   def room_factory do
     %Harmony.Chat.Room{
@@ -47,6 +48,19 @@ defmodule Harmony.Factory do
       body: "Hello",
       user: Harmony.AccountsFixtures.user_fixture(),
       room: build(:room)
+    }
+  end
+
+  def with_replies(%Message{} = message, count: count) do
+    insert_list(count, :reply, message: message)
+    message
+  end
+
+  def reply_factory do
+    %Harmony.Chat.Reply{
+      body: "Hello there",
+      user: Harmony.AccountsFixtures.user_fixture(),
+      message: build(:message)
     }
   end
 end


### PR DESCRIPTION
# Messages can have replies

Users see a `Reply` button when hovering over a message. They can click it to
open a drawer for replies to the message, along with a textarea for writing
their own replies. Messages with replies show a group of avatars from the users
who have replied to the message, along with the count of replies

## Show message replies in the reply drawer

Added the functionality to show replies in the reply drawer.
Of course, we don't yet have any way to actually *send* the replies.

The implementation uses the `get_message_with_replies` to get message,
it's replies, and the users/profiles in a single `Repo.get()`. This
results in a constant 6 queries:

* One for the `%Message{}`
* One for all of the `%Reply{}`s
* One for the `%Message{}` author
* One for the `%Message{}` author's profile
* One for all of the `%Reply{}` authors
* One for all of the `%Reply{}` authors' profiles

Fixed a long-standing N+1 query that was hitting the database once for
each message in a room to get the user profiles. We now preload them
with the message. This required updating some tests that manually create
messages and then send a message to the PubSub, because that broadcast
needs the profile preloaded as well.

## Users can create and delete replies

Added the core context functions for CRUD acts on `%Chat.Reply{}`,
including:

- `Chat.change_reply/2`: return a changeset for a `%Chat.Reply{}`
- `Chat.create_reply/3`: creates a reply for the given
`%Accounts.User{}` and `%Chat.Message{}`. Currently has no
authorization logic, but this can be added when needed.
- `delete_reply/2`: deletes the reply, as a specific `%Accounts.User{}`.
Checks if the user owns the reply before deleting it.`

Like with messages, the `create_reply` and `delete_reply` functions
broadcast a message on the PubSub topic for the **room** the reply is
in, of the form `{:new/delete_reply, message_id, reply}`. We send it to
the room because we may need to update the message items in the room
itself to show new replies as they come in. The `ChatRoomLive` view updates the
`@replies_parent` assign, which is used by the `RepliesComponent` to show the
actual replies (and the parent message).
